### PR TITLE
🚀 feat: Added Draggable, DropTarget and DraggableTarget components

### DIFF
--- a/src/powerhouse/components/drag-and-drop/__snapshots__/drag-and-drop.test.tsx.snap
+++ b/src/powerhouse/components/drag-and-drop/__snapshots__/drag-and-drop.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DragAndDrop Components Draggable should match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    aria-describedby="react-aria-description-0"
+    draggable="true"
+  >
+    <div
+      style="width: 100px; height: 100px;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DragAndDrop Components DraggableTarget should match snapshot 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      aria-describedby="react-aria-description-3"
+      draggable="true"
+    >
+      <div
+        style="width: 100px; height: 100px;"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DragAndDrop Components DropTarget should match snapshot 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      style="width: 100px; height: 100px;"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/src/powerhouse/components/drag-and-drop/constants.ts
+++ b/src/powerhouse/components/drag-and-drop/constants.ts
@@ -1,0 +1,1 @@
+export const CUSTOM_OBJECT_FORMAT = 'custom/object';

--- a/src/powerhouse/components/drag-and-drop/drag-and-drop.stories.tsx
+++ b/src/powerhouse/components/drag-and-drop/drag-and-drop.stories.tsx
@@ -1,0 +1,192 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Draggable } from './draggable';
+import { DraggableTarget } from './draggable-target';
+import { DropTarget } from './drop-target';
+
+const meta = {
+    title: 'Components/DragAndDrop',
+    component: DropTarget,
+    argTypes: {
+        id: { control: { type: 'text' } },
+    },
+} satisfies Meta<typeof DropTarget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Partial<Story> = {
+    render: () => (
+        <div>
+            <Draggable item={{ id: 'item-1', name: 'Item 1' }}>
+                {({ isDragging }) => (
+                    <div
+                        style={{
+                            width: 80,
+                            height: 30,
+                            textAlign: 'center',
+                            border: '1px solid black',
+                            backgroundColor: isDragging ? 'red' : 'blue',
+                        }}
+                    >
+                        Drag me!
+                    </div>
+                )}
+            </Draggable>
+            <div
+                style={{
+                    display: 'flex',
+                    width: 400,
+                    height: 400,
+                    border: '1px solid black',
+                }}
+            >
+                <DropTarget
+                    target={{ id: 'parent', name: 'Parent' }}
+                    onDropEvent={action('onDropEvent')}
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                    }}
+                >
+                    {({ isDropTarget }) => (
+                        <div
+                            style={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                width: '100%',
+                                height: '100%',
+                                backgroundColor: isDropTarget
+                                    ? 'yellow'
+                                    : 'lightblue',
+                            }}
+                        >
+                            <div
+                                style={{
+                                    width: '200px',
+                                    height: '200px',
+                                    border: '1px solid black',
+                                }}
+                            >
+                                <DropTarget
+                                    target={{ id: 'child', name: 'Child' }}
+                                    onDropEvent={action('onDropEvent')}
+                                    style={{ width: '100%', height: '100%' }}
+                                >
+                                    {({ isDropTarget }) => (
+                                        <div
+                                            style={{
+                                                display: 'flex',
+                                                justifyContent: 'center',
+                                                alignItems: 'center',
+                                                width: '100%',
+                                                height: '100%',
+                                                backgroundColor: isDropTarget
+                                                    ? 'yellow'
+                                                    : 'lightblue',
+                                            }}
+                                        />
+                                    )}
+                                </DropTarget>
+                            </div>
+                        </div>
+                    )}
+                </DropTarget>
+            </div>
+        </div>
+    ),
+};
+
+type ItemType = {
+    id: string;
+    name: string;
+};
+
+type ItemListType = ItemType & {
+    children?: ItemListType[];
+};
+
+const listItems: ItemListType[] = [
+    {
+        id: 'item-1',
+        name: 'Item 1',
+        children: [
+            {
+                id: 'item-1-1',
+                name: 'Item 1-1',
+            },
+            {
+                id: 'item-1-2',
+                name: 'Item 1-2',
+                children: [
+                    {
+                        id: 'item-1-2-1',
+                        name: 'Item 1-2-1',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'item-2',
+        name: 'Item 2',
+        children: [
+            {
+                id: 'item-2-1',
+                name: 'Item 2-1',
+            },
+            {
+                id: 'item-2-2',
+                name: 'Item 2-2',
+            },
+        ],
+    },
+    {
+        id: 'item-3',
+        name: 'Item 3',
+    },
+    {
+        id: 'item-4',
+        name: 'Item 4',
+    },
+    {
+        id: 'item-5',
+        name: 'Item 5',
+    },
+];
+
+const ListItems = () => {
+    const renderItem = (item: ItemListType) => (
+        <DraggableTarget<ItemListType>
+            key={item.id}
+            item={item}
+            onDropEvent={action('onDropEvent')}
+        >
+            {({ isDropTarget }) => (
+                <div
+                    style={{
+                        margin: 12,
+                        padding: 12,
+                        border: '1px solid black',
+                        backgroundColor: isDropTarget ? 'lightblue' : 'white',
+                    }}
+                >
+                    <div>{item.name}</div>
+                    {item.children && (
+                        <div>
+                            {item.children.map(child => renderItem(child))}
+                        </div>
+                    )}
+                </div>
+            )}
+        </DraggableTarget>
+    );
+
+    return <div>{listItems.map(item => renderItem(item))}</div>;
+};
+
+export const DraggableTargetComponent: Partial<Story> = {
+    name: 'DraggableTarget',
+    render: () => <ListItems />,
+};

--- a/src/powerhouse/components/drag-and-drop/drag-and-drop.test.tsx
+++ b/src/powerhouse/components/drag-and-drop/drag-and-drop.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react';
+
+import { Draggable } from './draggable';
+import { DraggableTarget } from './draggable-target';
+import { DropTarget } from './drop-target';
+
+describe('DragAndDrop Components', () => {
+    describe('Draggable', () => {
+        it('should match snapshot', () => {
+            const { asFragment } = render(
+                <Draggable item={{ id: 'item-1' }}>
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </Draggable>,
+            );
+
+            expect(asFragment()).toMatchSnapshot();
+        });
+
+        it('should call children render prop function', () => {
+            const children = jest.fn();
+
+            render(<Draggable item={{ id: 'item-1' }}>{children}</Draggable>);
+
+            expect(children).toHaveBeenCalled();
+            expect(children).toHaveBeenCalledWith({ isDragging: false });
+        });
+
+        it('should inject props to the div wrapper element', () => {
+            render(
+                <Draggable item={{ id: 'item-1' }} data-testid="draggable-node">
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </Draggable>,
+            );
+
+            expect(screen.getByTestId('draggable-node')).toBeDefined();
+        });
+    });
+
+    describe('DropTarget', () => {
+        it('should match snapshot', () => {
+            const onDropEvent = jest.fn();
+
+            const { asFragment } = render(
+                <DropTarget target={{ id: 'item-1' }} onDropEvent={onDropEvent}>
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </DropTarget>,
+            );
+
+            expect(asFragment()).toMatchSnapshot();
+        });
+
+        it('should call children render prop function', () => {
+            const children = jest.fn();
+            const onDropEvent = jest.fn();
+
+            render(
+                <DropTarget target={{ id: 'item-1' }} onDropEvent={onDropEvent}>
+                    {children}
+                </DropTarget>,
+            );
+
+            expect(children).toHaveBeenCalled();
+            expect(children).toHaveBeenCalledWith({ isDropTarget: false });
+        });
+
+        it('should inject props to the div wrapper element', () => {
+            const onDropEvent = jest.fn();
+
+            render(
+                <DropTarget
+                    target={{ id: 'item-1' }}
+                    onDropEvent={onDropEvent}
+                    data-testid="drop-target-node"
+                >
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </DropTarget>,
+            );
+
+            expect(screen.getByTestId('drop-target-node')).toBeDefined();
+        });
+    });
+
+    describe('DraggableTarget', () => {
+        it('should match snapshot', () => {
+            const { asFragment } = render(
+                <DraggableTarget item={{ id: 'item-1' }} onDropEvent={() => {}}>
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </DraggableTarget>,
+            );
+
+            expect(asFragment()).toMatchSnapshot();
+        });
+
+        it('should call children render prop function', () => {
+            const children = jest.fn();
+            const onDropEvent = jest.fn();
+
+            render(
+                <DraggableTarget
+                    item={{ id: 'item-1' }}
+                    onDropEvent={onDropEvent}
+                >
+                    {children}
+                </DraggableTarget>,
+            );
+
+            expect(children).toHaveBeenCalled();
+            expect(children).toHaveBeenCalledWith({
+                isDragging: false,
+                isDropTarget: false,
+            });
+        });
+
+        it('should inject props to the div wrapper elements', async () => {
+            const onDropEvent = jest.fn();
+
+            render(
+                <DraggableTarget
+                    item={{ id: 'item-1' }}
+                    onDropEvent={onDropEvent}
+                    targetNodeProps={{ id: 'target-node', className: 'target' }}
+                    dragNodeProps={{
+                        id: 'draggable-node',
+                        className: 'draggable',
+                    }}
+                >
+                    {() => <div style={{ width: '100px', height: '100px' }} />}
+                </DraggableTarget>,
+            );
+
+            const targetComponent = document.querySelector('#target-node');
+            const draggableComponent =
+                document.querySelector('#draggable-node');
+
+            expect(targetComponent).toBeDefined();
+            expect(targetComponent).toHaveClass('target');
+            expect(draggableComponent).toBeDefined();
+            expect(draggableComponent).toHaveClass('draggable');
+        });
+    });
+});

--- a/src/powerhouse/components/drag-and-drop/draggable-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable-target.tsx
@@ -1,0 +1,41 @@
+import { Draggable, DraggableRenderProps } from './draggable';
+import {
+    DropTarget,
+    DropTargetProps,
+    DropTargetRenderProps,
+} from './drop-target';
+
+export type DraggableTargetRenderProps = DraggableRenderProps &
+    DropTargetRenderProps;
+
+export interface DraggableTargetProps<Item = any> {
+    item: Item;
+    onDropEvent: DropTargetProps<Item, Item>['onDropEvent'];
+    children: (props: DraggableTargetRenderProps) => React.ReactNode;
+    dragNodeProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
+    targetNodeProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
+}
+
+export function DraggableTarget<Item = any>(props: DraggableTargetProps<Item>) {
+    const {
+        item,
+        onDropEvent,
+        children,
+        dragNodeProps = {},
+        targetNodeProps = {},
+    } = props;
+
+    return (
+        <DropTarget<Item, Item>
+            onDropEvent={onDropEvent}
+            target={item}
+            {...targetNodeProps}
+        >
+            {({ isDropTarget }) => (
+                <Draggable<Item> item={item} {...dragNodeProps}>
+                    {({ isDragging }) => children({ isDropTarget, isDragging })}
+                </Draggable>
+            )}
+        </DropTarget>
+    );
+}

--- a/src/powerhouse/components/drag-and-drop/draggable-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable-target.tsx
@@ -8,7 +8,7 @@ import {
 export type DraggableTargetRenderProps = DraggableRenderProps &
     DropTargetRenderProps;
 
-export interface DraggableTargetProps<Item = any> {
+export interface DraggableTargetProps<Item = unknown> {
     item: Item;
     onDropEvent: DropTargetProps<Item, Item>['onDropEvent'];
     children: (props: DraggableTargetRenderProps) => React.ReactNode;
@@ -16,7 +16,9 @@ export interface DraggableTargetProps<Item = any> {
     targetNodeProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
 }
 
-export function DraggableTarget<Item = any>(props: DraggableTargetProps<Item>) {
+export function DraggableTarget<Item = unknown>(
+    props: DraggableTargetProps<Item>,
+) {
     const {
         item,
         onDropEvent,

--- a/src/powerhouse/components/drag-and-drop/draggable-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable-target.tsx
@@ -14,6 +14,7 @@ export interface DraggableTargetProps<Item = unknown> {
     children: (props: DraggableTargetRenderProps) => React.ReactNode;
     dragNodeProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
     targetNodeProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>;
+    dataType?: string;
 }
 
 export function DraggableTarget<Item = unknown>(
@@ -21,8 +22,9 @@ export function DraggableTarget<Item = unknown>(
 ) {
     const {
         item,
-        onDropEvent,
+        dataType,
         children,
+        onDropEvent,
         dragNodeProps = {},
         targetNodeProps = {},
     } = props;
@@ -31,10 +33,15 @@ export function DraggableTarget<Item = unknown>(
         <DropTarget<Item, Item>
             onDropEvent={onDropEvent}
             target={item}
+            dataType={dataType}
             {...targetNodeProps}
         >
             {({ isDropTarget }) => (
-                <Draggable<Item> item={item} {...dragNodeProps}>
+                <Draggable<Item>
+                    item={item}
+                    dataType={dataType}
+                    {...dragNodeProps}
+                >
                     {({ isDragging }) => children({ isDropTarget, isDragging })}
                 </Draggable>
             )}

--- a/src/powerhouse/components/drag-and-drop/draggable.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable.tsx
@@ -1,0 +1,32 @@
+import { useDrag } from 'react-aria';
+import { CUSTOM_OBJECT_FORMAT } from './constants';
+
+export interface DraggableRenderProps {
+    isDragging: boolean;
+}
+
+export interface DraggableProps<Item = any>
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+    children?: (props: DraggableRenderProps) => React.ReactNode;
+    item: Item;
+}
+
+export function Draggable<Item = any>(props: DraggableProps<Item>) {
+    const { item, children, ...divProps } = props;
+
+    if (!children) return null;
+
+    const { dragProps, isDragging } = useDrag({
+        getItems: () => [
+            {
+                [CUSTOM_OBJECT_FORMAT]: JSON.stringify(item),
+            },
+        ],
+    });
+
+    return (
+        <div {...dragProps} {...divProps}>
+            {children({ isDragging })}
+        </div>
+    );
+}

--- a/src/powerhouse/components/drag-and-drop/draggable.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable.tsx
@@ -9,17 +9,18 @@ export interface DraggableProps<Item = unknown>
     extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
     children?: (props: DraggableRenderProps) => React.ReactNode;
     item: Item;
+    dataType?: string;
 }
 
 export function Draggable<Item = unknown>(props: DraggableProps<Item>) {
-    const { item, children, ...divProps } = props;
+    const { item, children, dataType, ...divProps } = props;
 
     if (!children) return null;
 
     const { dragProps, isDragging } = useDrag({
         getItems: () => [
             {
-                [CUSTOM_OBJECT_FORMAT]: JSON.stringify(item),
+                [dataType || CUSTOM_OBJECT_FORMAT]: JSON.stringify(item),
             },
         ],
     });

--- a/src/powerhouse/components/drag-and-drop/draggable.tsx
+++ b/src/powerhouse/components/drag-and-drop/draggable.tsx
@@ -5,13 +5,13 @@ export interface DraggableRenderProps {
     isDragging: boolean;
 }
 
-export interface DraggableProps<Item = any>
+export interface DraggableProps<Item = unknown>
     extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
     children?: (props: DraggableRenderProps) => React.ReactNode;
     item: Item;
 }
 
-export function Draggable<Item = any>(props: DraggableProps<Item>) {
+export function Draggable<Item = unknown>(props: DraggableProps<Item>) {
     const { item, children, ...divProps } = props;
 
     if (!children) return null;
@@ -25,7 +25,7 @@ export function Draggable<Item = any>(props: DraggableProps<Item>) {
     });
 
     return (
-        <div {...dragProps} {...divProps}>
+        <div {...dragProps} role="button" tabIndex={0} {...divProps}>
             {children({ isDragging })}
         </div>
     );

--- a/src/powerhouse/components/drag-and-drop/drop-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/drop-target.tsx
@@ -13,12 +13,13 @@ export interface DropTargetProps<Target = unknown, Item = unknown>
     target: Target;
     children?: (props: DropTargetRenderProps) => React.ReactNode;
     onDropEvent: (item: Item, target: Target, event: DropEvent) => void;
+    dataType?: string;
 }
 
 export function DropTarget<Target = unknown, Item = unknown>(
     props: DropTargetProps<Target, Item>,
 ) {
-    const { children, target, onDropEvent, ...divProps } = props;
+    const { children, target, onDropEvent, dataType, ...divProps } = props;
 
     if (!children) return null;
 
@@ -29,11 +30,13 @@ export function DropTarget<Target = unknown, Item = unknown>(
             const item = e.items.find(
                 item =>
                     item.kind === 'text' &&
-                    item.types.has(CUSTOM_OBJECT_FORMAT),
+                    item.types.has(dataType || CUSTOM_OBJECT_FORMAT),
             ) as TextDropItem | undefined;
 
             if (item) {
-                const result = await item.getText(CUSTOM_OBJECT_FORMAT);
+                const result = await item.getText(
+                    dataType || CUSTOM_OBJECT_FORMAT,
+                );
                 onDropEvent(JSON.parse(result) as Item, target, e);
             }
         },

--- a/src/powerhouse/components/drag-and-drop/drop-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/drop-target.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { useRef } from 'react';
+import { DropEvent, TextDropItem, useDrop } from 'react-aria';
+
+import { CUSTOM_OBJECT_FORMAT } from './constants';
+
+export interface DropTargetRenderProps {
+    isDropTarget: boolean;
+}
+
+export interface DropTargetProps<Target = any, Item = any>
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+    target: Target;
+    children?: (props: DropTargetRenderProps) => React.ReactNode;
+    onDropEvent: (item: Item, target: Target, event: DropEvent) => void;
+}
+
+export function DropTarget<Target = any, Item = any>(
+    props: DropTargetProps<Target, Item>,
+) {
+    const { children, target, onDropEvent, ...divProps } = props;
+
+    if (!children) return null;
+
+    const ref = useRef(null);
+    const { dropProps, isDropTarget } = useDrop({
+        ref,
+        async onDrop(e) {
+            const item = e.items.find(
+                item =>
+                    item.kind === 'text' &&
+                    item.types.has(CUSTOM_OBJECT_FORMAT),
+            ) as TextDropItem | undefined;
+
+            if (item) {
+                const result = await item.getText(CUSTOM_OBJECT_FORMAT);
+                onDropEvent(JSON.parse(result) as Item, target, e);
+            }
+        },
+    });
+
+    return (
+        <div {...divProps} {...dropProps} ref={ref}>
+            {children({ isDropTarget })}
+        </div>
+    );
+}

--- a/src/powerhouse/components/drag-and-drop/drop-target.tsx
+++ b/src/powerhouse/components/drag-and-drop/drop-target.tsx
@@ -8,14 +8,14 @@ export interface DropTargetRenderProps {
     isDropTarget: boolean;
 }
 
-export interface DropTargetProps<Target = any, Item = any>
+export interface DropTargetProps<Target = unknown, Item = unknown>
     extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
     target: Target;
     children?: (props: DropTargetRenderProps) => React.ReactNode;
     onDropEvent: (item: Item, target: Target, event: DropEvent) => void;
 }
 
-export function DropTarget<Target = any, Item = any>(
+export function DropTarget<Target = unknown, Item = unknown>(
     props: DropTargetProps<Target, Item>,
 ) {
     const { children, target, onDropEvent, ...divProps } = props;

--- a/src/powerhouse/components/drag-and-drop/index.ts
+++ b/src/powerhouse/components/drag-and-drop/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './draggable';
 export * from './draggable-target';
 export * from './drop-target';

--- a/src/powerhouse/components/drag-and-drop/index.ts
+++ b/src/powerhouse/components/drag-and-drop/index.ts
@@ -1,0 +1,3 @@
+export * from './draggable';
+export * from './draggable-target';
+export * from './drop-target';

--- a/src/powerhouse/components/index.ts
+++ b/src/powerhouse/components/index.ts
@@ -1,3 +1,4 @@
 export * from './button';
+export * from './drag-and-drop';
 export * from './legacy';
 export * from './sidebar';


### PR DESCRIPTION
## Description:

- Added `Draggable` component: turns any component into a draggable item
- Added `DropTarget` component: turns any component into a valid drop target
- Added `DraggableTarget` component: turns any component into a draggable item and a drop target at the same time


![2023-10-19 00 34 07](https://github.com/powerhouse-inc/design-system/assets/20387722/b9964a30-13ee-4aeb-9866-8243a82e66b0)


![2023-10-19 00 34 57](https://github.com/powerhouse-inc/design-system/assets/20387722/08861a2d-9d48-4783-a8b8-943ed7638b23)
