### PR TITLE
🚀 feat: Enabled DragAndDrop into Connect TreeView

### DIFF
--- a/src/connect/components/tree-view-item/tree-view-item.stories.tsx
+++ b/src/connect/components/tree-view-item/tree-view-item.stories.tsx
@@ -7,24 +7,10 @@ const meta = {
     argTypes: {
         onClick: { control: { type: 'action' } },
         onOptionsClick: { control: { type: 'action' } },
-        initialOpen: { control: { type: 'boolean' } },
         buttonProps: { control: { type: 'object' } },
         optionsButtonProps: { control: { type: 'object' } },
         level: { control: { type: 'number' } },
-        status: {
-            control: { type: 'select' },
-            options: ['available', 'available-offline', 'syncing', 'offline'],
-        },
-        type: {
-            control: { type: 'select' },
-            options: [
-                'folder',
-                'file',
-                'local-drive',
-                'network-drive',
-                'public-drive',
-            ],
-        },
+        item: { control: { type: 'object' } },
     },
 } satisfies Meta<typeof ConnectTreeViewItem>;
 
@@ -33,9 +19,13 @@ type Story = StoryObj<typeof meta>;
 
 export const TreeViewItem: Story = {
     args: {
-        label: 'Folder 1',
-        status: 'syncing' as ItemStatus,
-        type: 'folder' as ItemType,
         level: 0,
+        item: {
+            id: 'drive/folder1',
+            label: 'Folder 1',
+            type: ItemType.Folder,
+            status: ItemStatus.Syncing,
+            expanded: false,
+        },
     },
 };

--- a/src/connect/components/tree-view/tree-view.stories.tsx
+++ b/src/connect/components/tree-view/tree-view.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ItemStatus, ItemType } from '../tree-view-item';
-import { ConnectTreeView, TreeItem } from './tree-view';
+import { ItemStatus, ItemType, TreeItem } from '../tree-view-item';
+import { ConnectTreeView } from './tree-view';
 
 const meta = {
     title: 'Connect/Components',
@@ -8,6 +8,7 @@ const meta = {
     argTypes: {
         items: { control: { type: 'object' } },
         onItemClick: { control: { type: 'action' } },
+        onDropEvent: { control: { type: 'action' } },
         onItemOptionsClick: { control: { type: 'action' } },
     },
 } satisfies Meta<typeof ConnectTreeView>;

--- a/src/connect/components/tree-view/tree-view.tsx
+++ b/src/connect/components/tree-view/tree-view.tsx
@@ -1,35 +1,40 @@
 import React from 'react';
-import { PressEvent } from 'react-aria-components';
 
-import { ConnectTreeViewItem, ItemStatus, ItemType } from '../tree-view-item';
-
-export interface TreeItem {
-    id: string;
-    label: string;
-    type: ItemType;
-    status?: ItemStatus;
-    expanded?: boolean;
-    children?: TreeItem[];
-}
+import {
+    ConnectTreeViewItem,
+    ConnectTreeViewItemProps,
+    TreeItem,
+} from '../tree-view-item';
 
 export interface ConnectTreeViewProps
     extends Omit<React.HTMLAttributes<HTMLElement>, 'onClick'> {
     items: TreeItem;
-    onItemClick?: (event: PressEvent, item: TreeItem) => void;
-    onItemOptionsClick?: (event: PressEvent, item: TreeItem) => void;
+    onDropEvent?: ConnectTreeViewItemProps['onDropEvent'];
+    onItemClick?: (
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+        item: TreeItem,
+    ) => void;
+    onItemOptionsClick?: (
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+        item: TreeItem,
+    ) => void;
 }
 
 export const ConnectTreeView: React.FC<ConnectTreeViewProps> = props => {
-    const { items, onItemClick, onItemOptionsClick, ...elementProps } = props;
+    const {
+        items,
+        onItemClick,
+        onDropEvent,
+        onItemOptionsClick,
+        ...elementProps
+    } = props;
 
     const renderTreeItems = (item: TreeItem, level = 0) => {
         return (
             <ConnectTreeViewItem
+                item={item}
                 key={item.id}
-                type={item.type}
-                label={item.label}
-                status={item.status}
-                initialOpen={item.expanded}
+                onDropEvent={onDropEvent}
                 onClick={e => onItemClick?.(e, item)}
                 onOptionsClick={e => onItemOptionsClick?.(e, item)}
                 {...elementProps}

--- a/src/powerhouse/components/drag-and-drop/drag-and-drop.stories.tsx
+++ b/src/powerhouse/components/drag-and-drop/drag-and-drop.stories.tsx
@@ -1,5 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
+import { useDraggableTarget } from '../../hooks/useDraggableTarget';
 import { Draggable } from './draggable';
 import { DraggableTarget } from './draggable-target';
 import { DropTarget } from './drop-target';
@@ -189,4 +190,42 @@ const ListItems = () => {
 export const DraggableTargetComponent: Partial<Story> = {
     name: 'DraggableTarget',
     render: () => <ListItems />,
+};
+
+const DraggableElement: React.FC<ItemType> = props => {
+    const { dragProps, dropProps, isDropTarget } = useDraggableTarget<ItemType>(
+        {
+            data: {
+                id: props.id,
+                name: props.name,
+            },
+            onDropEvent: action('onDropEvent'),
+        },
+    );
+
+    return (
+        <div
+            {...dragProps}
+            {...dropProps}
+            onClick={action('onClick')}
+            style={{
+                backgroundColor: isDropTarget ? 'yellow' : 'lightblue',
+                width: '60px',
+                height: '30px',
+            }}
+        >
+            {props.name}
+        </div>
+    );
+};
+
+export const UseDraggableTargetHook: Partial<Story> = {
+    name: 'useDraggableTarget',
+    render: () => (
+        <div>
+            <DraggableElement id="item-1" name="Item 1" />
+            <DraggableElement id="item-2" name="Item 2" />
+            <DraggableElement id="item-3" name="Item 3" />
+        </div>
+    ),
 };

--- a/src/powerhouse/components/tree-view-item/TreeViewItem.tsx
+++ b/src/powerhouse/components/tree-view-item/TreeViewItem.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Button, ButtonProps, PressEvent } from 'react-aria-components';
 import { twMerge } from 'tailwind-merge';
 import CaretIcon from '../../../assets/icons/caret.svg';
 import VerticalDots from '../../../assets/icons/vertical-dots.svg';
@@ -12,11 +11,13 @@ export interface TreeViewItemProps
     expandedIcon?: string;
     icon?: string;
     level?: number;
-    onClick?: (event: PressEvent) => void;
-    onOptionsClick?: (event: PressEvent) => void;
+    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onOptionsClick?: (
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    ) => void;
     secondaryIcon?: string;
-    buttonProps?: ButtonProps;
-    optionsButtonProps?: ButtonProps;
+    buttonProps?: React.HTMLAttributes<HTMLDivElement>;
+    optionsButtonProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 const injectLevelProps = (
@@ -69,9 +70,18 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
         setOpen(initialOpen);
     }, [initialOpen]);
 
-    const onClickItemHandler = (e: PressEvent) => {
+    const onClickItemHandler = (
+        e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    ) => {
         toggleOpen();
         onClick && onClick(e);
+    };
+
+    const onOptionsClickHandler = (
+        e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    ) => {
+        e.stopPropagation();
+        onOptionsClick && onOptionsClick(e);
     };
 
     const {
@@ -87,16 +97,16 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
 
     return (
         <div {...divProps}>
-            <Button
-                onPress={onClickItemHandler}
+            <div
+                role="button"
+                onClick={onClickItemHandler}
                 style={{
                     paddingLeft: `${level * 10}px`,
                     ...containerButtonStyle,
                 }}
                 className={twMerge(
                     'flex flex-row w-full cursor-pointer select-none group focus:outline-none',
-                    typeof containerButtonClassName === 'string' &&
-                        containerButtonClassName,
+                    containerButtonClassName,
                 )}
                 {...containerButtonProps}
             >
@@ -110,17 +120,17 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
                 {icon && <img src={open ? expandedIcon || icon : icon} />}
                 {label && <div className="ml-1 flex flex-1">{label}</div>}
                 {onOptionsClick && (
-                    <Button
-                        onPress={onOptionsClick}
+                    <div
+                        role="button"
+                        onClick={onOptionsClickHandler}
                         className={twMerge(
                             'w-6 h-6 mx-3 hidden group-hover:inline-block focus:outline-none',
-                            typeof optionsButtonClassName === 'string' &&
-                                optionsButtonClassName,
+                            optionsButtonClassName,
                         )}
                         {...containerOptionsButtonProps}
                     >
                         <img src={VerticalDots} className="w-6 h-6" />
-                    </Button>
+                    </div>
                 )}
                 {secondaryIcon && (
                     <img
@@ -128,7 +138,7 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
                         className="flex self-end w-6 h-6 mx-3 group-hover:hidden"
                     />
                 )}
-            </Button>
+            </div>
             {children && (
                 <div className={twMerge(!open && 'hidden')}>
                     {injectLevelProps(children, level)}

--- a/src/powerhouse/hooks/index.ts
+++ b/src/powerhouse/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './reducer';
+export * from './useDraggableTarget';

--- a/src/powerhouse/hooks/useDraggableTarget.ts
+++ b/src/powerhouse/hooks/useDraggableTarget.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { useRef } from 'react';
+import { DropEvent, TextDropItem, useDrag, useDrop } from 'react-aria';
+import { CUSTOM_OBJECT_FORMAT } from '../components/drag-and-drop/constants';
+
+export interface UseDraggableTargetProps<T = unknown> {
+    data: T;
+    onDropEvent?: (item: T, target: T, event: DropEvent) => void;
+    dataType?: string;
+}
+
+export function useDraggableTarget<T = unknown>(
+    props: UseDraggableTargetProps<T>,
+) {
+    const { data, onDropEvent, dataType } = props;
+
+    const ref = useRef(null);
+
+    const { dragProps, isDragging } = useDrag({
+        getItems: () => [
+            {
+                [dataType || CUSTOM_OBJECT_FORMAT]: JSON.stringify(data),
+            },
+        ],
+    });
+
+    const { dropProps, isDropTarget } = useDrop({
+        ref,
+        async onDrop(e) {
+            const item = e.items.find(
+                item =>
+                    item.kind === 'text' &&
+                    item.types.has(dataType || CUSTOM_OBJECT_FORMAT),
+            ) as TextDropItem | undefined;
+
+            if (item) {
+                const result = await item.getText(
+                    dataType || CUSTOM_OBJECT_FORMAT,
+                );
+                onDropEvent?.(JSON.parse(result) as T, data, e);
+            }
+        },
+    });
+
+    return { dragProps, dropProps, isDropTarget, isDragging };
+}


### PR DESCRIPTION
## Description

- Added `useDraggableTarget` hook
- Refactor `TreeViewItem` to use `div` instead of `react-aria` `Button` (see note below)(added `role="button"`)
- Refactor `ConnectTreeView` and `ConnectTreeViewItem` to support Drag and Drop

> **_NOTE 1:_** props returned by `useDrag` and `useDrop` are incompatible with react-aria `Button` props.

> **_NOTE 2:_** Styles for drop target needs to be changed once they are defined in the designs.


![2023-10-20 16 55 02](https://github.com/powerhouse-inc/design-system/assets/20387722/79c95543-d57c-42d0-a826-b22bc5439981)
