### PR TITLE
refactor: refactor tree-view-item to render the caret icon only when there are children nodes

### DIFF
--- a/src/powerhouse/components/tree-view-item/tree-view-item.tsx
+++ b/src/powerhouse/components/tree-view-item/tree-view-item.tsx
@@ -95,13 +95,16 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
         ...containerOptionsButtonProps
     } = optionsButtonProps;
 
+    const levelPadding = level * 10;
+    const caretPadding = children ? 0 : 24;
+
     return (
         <div {...divProps}>
             <div
                 role="button"
                 onClick={onClickItemHandler}
                 style={{
-                    paddingLeft: `${level * 10}px`,
+                    paddingLeft: `${levelPadding + caretPadding}px`,
 
                     ...containerButtonStyle,
                 }}
@@ -111,13 +114,15 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
                 )}
                 {...containerButtonProps}
             >
-                <img
-                    src={CaretIcon}
-                    className={twMerge(
-                        open && 'rotate-90',
-                        'transition ease delay-50 pointer-events-none',
-                    )}
-                />
+                {children && (
+                    <img
+                        src={CaretIcon}
+                        className={twMerge(
+                            open && 'rotate-90',
+                            'transition ease delay-50 pointer-events-none',
+                        )}
+                    />
+                )}
                 {icon && (
                     <img
                         src={open ? expandedIcon || icon : icon}


### PR DESCRIPTION
## Description:

- refactor tree-view-item to render the caret icon only when there are children nodes

![Screenshot 2023-10-25 at 17 06 50](https://github.com/powerhouse-inc/design-system/assets/20387722/03267564-2366-4ffe-a975-71de1d5cc828)
