### PR TITLE
fix: 🎨 tree-view-input styles

### DIFF
--- a/src/connect/components/tree-view-input/tree-view-input.tsx
+++ b/src/connect/components/tree-view-input/tree-view-input.tsx
@@ -32,12 +32,14 @@ export const ConnectTreeViewInput: React.FC<
             icon={<Icon name="folder-close" color="#6C7275" />}
             submitIcon={
                 <Icon
+                    color="#6C7275"
                     name="check"
                     className="transition-colors hover:text-[#34A853]"
                 />
             }
             cancelIcon={
                 <Icon
+                    color="#6C7275"
                     name="xmark"
                     className="transition-colors hover:text-[#EA4335]"
                 />

--- a/src/powerhouse/components/tree-view-input/__snapshots__/tree-view-input.test.tsx.snap
+++ b/src/powerhouse/components/tree-view-input/__snapshots__/tree-view-input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TreeViewInput Component > should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-row items-center pr-5"
+    class="flex flex-row items-center pr-4"
     style="padding-left: 24px;"
   >
     <div>
@@ -34,16 +34,16 @@ exports[`TreeViewInput Component > should match snapshot 1`] = `
         type="button"
       >
         <div>
-          Submit Icon
+          Cancel Icon
         </div>
       </button>
       <button
-        class="ml-1 outline-none"
+        class="outline-none"
         data-rac=""
         type="button"
       >
         <div>
-          Cancel Icon
+          Submit Icon
         </div>
       </button>
     </div>

--- a/src/powerhouse/components/tree-view-input/tree-view-input.tsx
+++ b/src/powerhouse/components/tree-view-input/tree-view-input.tsx
@@ -59,7 +59,7 @@ export const TreeViewInput: React.FC<TreeViewInputProps> = props => {
         <ClickAwayListener onClickAway={() => onSubmit(text)}>
             <div
                 className={twMerge(
-                    'flex flex-row items-center pr-5',
+                    'flex flex-row items-center pr-4',
                     className,
                 )}
                 style={{
@@ -84,20 +84,17 @@ export const TreeViewInput: React.FC<TreeViewInputProps> = props => {
                     />
                 </TextField>
                 <div className="flex flex-row items-center">
+                    {cancelIcon && (
+                        <Button onPress={onCancel} className="outline-none">
+                            {cancelIcon}
+                        </Button>
+                    )}
                     <Button
                         className="outline-none"
                         onPress={e => onSubmit(text, e)}
                     >
                         {submitIcon}
                     </Button>
-                    {cancelIcon && (
-                        <Button
-                            onPress={onCancel}
-                            className="ml-1 outline-none"
-                        >
-                            {cancelIcon}
-                        </Button>
-                    )}
                 </div>
             </div>
         </ClickAwayListener>


### PR DESCRIPTION
## Description:

- Fix `tree-view-input` styles

<img width="430" alt="Screenshot 2023-11-22 at 09 08 23" src="https://github.com/powerhouse-inc/design-system/assets/20387722/e94495a2-b01d-457b-9672-5a3c6252c4e6">
