### PR TITLE
feat: remove id field from tables

### DIFF
--- a/src/rwa/components/table/fixed-income-assets-table.stories.tsx
+++ b/src/rwa/components/table/fixed-income-assets-table.stories.tsx
@@ -38,7 +38,6 @@ const columnCountByTableWidth = {
 };
 
 const fieldsPriority: (keyof FixedIncomeAsset)[] = [
-    'id',
     'name',
     'maturity',
     'notional',

--- a/src/rwa/components/table/useColumnPriority.ts
+++ b/src/rwa/components/table/useColumnPriority.ts
@@ -59,6 +59,8 @@ export function useColumnPriority<TItem extends Record<string, ReactNode>>(
               }
             : undefined;
         const headerLabelsFromItems = fields
+            // the id field is for internal use and is not useful to the user
+            .filter(field => field !== 'id')
             .map(field => ({
                 id: field,
                 label: field,


### PR DESCRIPTION
we have agreed that the id field is not useful to the user and is just taking up space.

filter out the id field from the table headers. this causes the field to also be ignored by the table, without needing special business logic.

however, I will also need to update the `fieldsPriority` that already exists in the `document-model-libs` for the rwa editor, because it assumes that `id` is still one of the columns to show.