### PR TITLE
fix: deal with Date objects on maybeStripTime util

### DIFF
--- a/src/rwa/components/table/utils.ts
+++ b/src/rwa/components/table/utils.ts
@@ -1,9 +1,14 @@
+export function isISODate(str: string) {
+    if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) return false;
+    const d = new Date(str);
+    return d instanceof Date && !isNaN(d.getTime()) && d.toISOString() === str;
+}
+
 export function maybeStripTime(
     maybeDate: string | number | Date | null | undefined,
 ) {
     if (!maybeDate || typeof maybeDate === 'number') return maybeDate;
-    const isDate =
-        maybeDate instanceof Date || !isNaN(new Date(maybeDate).getTime());
+    const isDate = maybeDate instanceof Date || isISODate(maybeDate);
     if (isDate) {
         const dateStr =
             maybeDate instanceof Date ? maybeDate.toISOString() : maybeDate;

--- a/src/rwa/components/table/utils.ts
+++ b/src/rwa/components/table/utils.ts
@@ -1,8 +1,13 @@
-export function maybeStripTime(maybeDate: string | number | null | undefined) {
+export function maybeStripTime(
+    maybeDate: string | number | Date | null | undefined,
+) {
     if (!maybeDate || typeof maybeDate === 'number') return maybeDate;
-    const isDate = !isNaN(new Date(maybeDate).getTime());
+    const isDate =
+        maybeDate instanceof Date || !isNaN(new Date(maybeDate).getTime());
     if (isDate) {
-        return maybeDate.split('T')[0];
+        const dateStr =
+            maybeDate instanceof Date ? maybeDate.toISOString() : maybeDate;
+        return dateStr.split('T')[0];
     }
     return maybeDate;
 }


### PR DESCRIPTION
Strings with a number and a `T` in the name were being altered, for example `'Test Asset 2' => ''`
Also fixes issue where Storybook would provide a `Date` object instead of `String`
Fixes #208 