### PR TITLE
feat: fix wrong tx object

### DIFF
--- a/src/rwa/components/table/group-transactions-table.tsx
+++ b/src/rwa/components/table/group-transactions-table.tsx
@@ -53,7 +53,7 @@ export function mapGroupTransactionToTableFields(
         'Entry time': transaction.entryTime,
         Asset: fixedIncome?.name,
         Quantity: transaction.fixedIncomeTransaction?.amount,
-        'Cash Amount': transaction.fixedIncomeTransaction?.amount,
+        'Cash Amount': transaction.cashTransaction?.amount,
         'Cash Balance Change': transaction.cashBalanceChange,
     };
 }


### PR DESCRIPTION
I had a fat finger mistake where I accidentally used the value for fixedIncomeTransaction where I should have used cashTransaction.