### PR TITLE
feat: use cash balance change as input

### DIFF
--- a/src/rwa/components/group-transaction-details/group-transaction-details.tsx
+++ b/src/rwa/components/group-transaction-details/group-transaction-details.tsx
@@ -153,6 +153,10 @@ export const GroupTransactionDetails: React.FC<
             ...data,
             cashAmount: Number(data.cashAmount),
             fixedIncomeAmount: Number(data.fixedIncomeAmount),
+            fees: data.fees?.map(fee => ({
+                ...fee,
+                amount: Number(fee.amount),
+            })),
             cashBalanceChange,
         });
     };

--- a/src/rwa/components/group-transaction-details/group-transaction-details.tsx
+++ b/src/rwa/components/group-transaction-details/group-transaction-details.tsx
@@ -31,13 +31,14 @@ export type GroupTransactionDetailInputs = {
     fixedIncomeId: string | undefined;
     fixedIncomeAmount: number | undefined;
     fees: Maybe<TransactionFee[]> | undefined;
+    cashBalanceChange: number | undefined;
 };
 
 function calculateUnitPricePercent(
     cashAmount: number | undefined,
     fixedIncomeAmount: number | undefined,
 ) {
-    if (!cashAmount || !fixedIncomeAmount) return '--';
+    if (!cashAmount || !fixedIncomeAmount) return 0;
     return ((cashAmount / fixedIncomeAmount) * 100).toFixed(2);
 }
 
@@ -46,7 +47,7 @@ function calculateCashBalanceChange(
     cashAmount: number | undefined,
     fees: Maybe<TransactionFee[]> | undefined,
 ) {
-    if (!cashAmount || !transactionType) return '--';
+    if (!cashAmount || !transactionType) return 0;
 
     const operation = transactionType === 'AssetPurchase' ? -1 : 1;
 
@@ -130,10 +131,6 @@ export const GroupTransactionDetails: React.FC<
         name: 'fees', // Name of the field array in your form
     });
 
-    const onSubmit: SubmitHandler<GroupTransactionDetailInputs> = data => {
-        onSubmitForm(data);
-    };
-
     const isEditOperation = operation === 'edit';
     const isCreateOperation = operation === 'create';
     const isViewOnly = !isCreateOperation && !isEditOperation;
@@ -150,6 +147,15 @@ export const GroupTransactionDetails: React.FC<
         cashAmount,
         fees,
     );
+
+    const onSubmit: SubmitHandler<GroupTransactionDetailInputs> = data => {
+        onSubmitForm({
+            ...data,
+            cashAmount: Number(data.cashAmount),
+            fixedIncomeAmount: Number(data.fixedIncomeAmount),
+            cashBalanceChange,
+        });
+    };
 
     return (
         <div

--- a/src/rwa/components/table/group-transactions-table.tsx
+++ b/src/rwa/components/table/group-transactions-table.tsx
@@ -53,7 +53,7 @@ export function mapGroupTransactionToTableFields(
         'Entry time': transaction.entryTime,
         Asset: fixedIncome?.name,
         Quantity: transaction.fixedIncomeTransaction?.amount,
-        'Cash Amount': transaction.fixedIncomeTransaction?.amount,
+        'Cash Amount': transaction.cashTransaction?.amount,
         'Cash Balance Change': transaction.cashBalanceChange,
     };
 }


### PR DESCRIPTION
trying to calculate the cash balance change in the document editor when dispatching events proves difficult because of the state state problem. the calculation needs the latest values for both operations, which is hard to access right now. this will be easy to implement once we can dispatch multiple operations. for now I am simply including it as an input, since we already have all the information we need available here.