### PR TITLE
feat: add error messages to input

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -221,3 +221,11 @@ html:has(dialog[open]) {
     height: 2px;
 }
 /* Toastify end */
+
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    margin: 0;
+}

--- a/src/rwa/components/asset-details/asset-details.tsx
+++ b/src/rwa/components/asset-details/asset-details.tsx
@@ -1,7 +1,7 @@
 import { DivProps, Icon, mergeClassNameProps } from '@/powerhouse';
 import { parseDate } from '@internationalized/date';
 import React from 'react';
-import { SubmitHandler, UseFormReset, useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import {
     FixedIncome,
     FixedIncomeType,
@@ -45,7 +45,7 @@ export interface RWAAssetDetailsProps extends DivProps {
     fixedIncomeTypes: FixedIncomeType[];
     spvs: SPV[];
     onClose?: () => void;
-    onCancel: (reset: UseFormReset<RWAAssetDetailInputs>) => void;
+    onCancel: () => void;
     selectItemToEdit?: () => void;
     onSubmitForm: (data: RWAAssetDetailInputs) => void;
     labels?: typeof defaultLabels;
@@ -72,7 +72,13 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
     );
     const spv = spvs.find(({ id }) => id === asset.spvId);
 
-    const { handleSubmit, control, reset } = useForm<RWAAssetDetailInputs>({
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors },
+    } = useForm<RWAAssetDetailInputs>({
         defaultValues: {
             fixedIncomeTypeId: fixedIncomeType?.id ?? fixedIncomeTypes[0].id,
             spvId: spv?.id ?? spvs[0].id,
@@ -85,8 +91,14 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
     });
 
     const onSubmit: SubmitHandler<RWAAssetDetailInputs> = data => {
+        if (Object.keys(errors).length !== 0) return;
         onSubmitForm(data);
     };
+
+    function handleCancel() {
+        reset();
+        onCancel();
+    }
 
     const isEditMode = mode === 'edit';
     const isCreateOperation = operation === 'create';
@@ -99,7 +111,7 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
                     {isEditMode ? (
                         <div className="flex gap-x-2">
                             <RWAButton
-                                onClick={() => onCancel(reset)}
+                                onClick={handleCancel}
                                 className="text-gray-600"
                             >
                                 {labels.cancelEdits}
@@ -143,9 +155,17 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
                     hideLine={isEditMode}
                     value={
                         <RWATableTextInput
-                            control={control}
-                            name="name"
-                            disabled={!isEditMode}
+                            {...register('name', {
+                                disabled: !isEditMode,
+                                required: 'Asset name is required',
+                            })}
+                            aria-invalid={
+                                errors.name?.type === 'required'
+                                    ? 'true'
+                                    : 'false'
+                            }
+                            errorMessage={errors.name?.message}
+                            placeholder="E.g. My Asset"
                         />
                     }
                 />
@@ -154,9 +174,8 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
                     hideLine={isEditMode}
                     value={
                         <RWATableTextInput
-                            control={control}
-                            name="CUSIP"
-                            disabled={!isEditMode}
+                            {...register('CUSIP', { disabled: !isEditMode })}
+                            placeholder="E.g. 123456789"
                         />
                     }
                 />
@@ -165,9 +184,8 @@ export const RWAAssetDetails: React.FC<RWAAssetDetailsProps> = props => {
                     hideLine={isEditMode}
                     value={
                         <RWATableTextInput
-                            control={control}
-                            name="ISIN"
-                            disabled={!isEditMode}
+                            {...register('ISIN', { disabled: !isEditMode })}
+                            placeholder="E.g. 123456789012"
                         />
                     }
                 />

--- a/src/rwa/components/table-inputs/form-row.tsx
+++ b/src/rwa/components/table-inputs/form-row.tsx
@@ -19,11 +19,11 @@ export const RWAFormRow: React.FC<RWAFormRowProps> = ({
             'flex min-h-12 items-center justify-between px-6 text-xs last:mb-4',
         )}
     >
-        <div className="mr-2 min-w-[25%] py-[7px] text-gray-600">{label}</div>
+        <div className="mr-2 min-w-[25%] py-2 text-gray-600">{label}</div>
         {!hideLine && (
             <div className="h-px flex-1 border-b border-dashed border-gray-400" />
         )}
-        <div className="ml-2 flex min-w-[25%] justify-end py-2 text-gray-900">
+        <div className="mb-1 ml-2 flex min-w-[25%] justify-end py-2 text-gray-900">
             {value ? value : '--'}
         </div>
     </div>

--- a/src/rwa/components/table-inputs/text-input.tsx
+++ b/src/rwa/components/table-inputs/text-input.tsx
@@ -1,64 +1,49 @@
-import { useNumberFormat } from '@react-input/number-format';
-import { Control, Controller, FieldValues, Path } from 'react-hook-form';
+import { ComponentPropsWithRef, ForwardedRef, forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { RWATextInput, RWATextInputProps } from '../text-input';
 
-export interface RWATableTextInputProps<ControlInputs extends FieldValues>
-    extends RWATextInputProps {
-    disabled?: boolean;
-    name: Path<ControlInputs>;
-    control: Control<ControlInputs>;
-    type?: React.HTMLInputTypeAttribute | 'currency';
-    required?: boolean;
-}
+type Props = ComponentPropsWithRef<'input'> & {
+    errorMessage?: string;
+    labelClassName?: string;
+    inputClassName?: string;
+    errorMessageClassName?: string;
+};
 
-export function RWATableTextInput<ControlInputs extends FieldValues>(
-    props: RWATableTextInputProps<ControlInputs>,
+export const RWATableTextInput = forwardRef(function RWATableTextInput(
+    props: Props,
+    ref: ForwardedRef<HTMLInputElement>,
 ) {
+    const invalid = props['aria-invalid'] === 'true';
     const {
-        name,
-        control,
-        type = 'text',
-        required = false,
-        disabled = false,
-        ...restProps
+        errorMessage,
+        labelClassName,
+        inputClassName,
+        errorMessageClassName,
+        ...inputProps
     } = props;
 
-    const inputProps: RWATextInputProps['inputProps'] = { type };
-
-    const currencyInputRef = useNumberFormat({
-        locales: 'en',
-        format: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 2,
-    });
-
-    if (type === 'currency') {
-        inputProps.ref = currencyInputRef;
-    }
-
     return (
-        <Controller
-            name={name}
-            control={control}
-            rules={{ required }}
-            render={({ field: { onChange, onBlur, value } }) => (
-                <RWATextInput
-                    value={value}
-                    onBlur={onBlur}
-                    onChange={onChange}
-                    textFieldProps={{ isDisabled: disabled }}
-                    inputProps={{
-                        className: 'text-right',
-                        ...inputProps,
-                    }}
+        <label className={labelClassName}>
+            <input
+                {...inputProps}
+                ref={ref}
+                className={twMerge(
+                    'size-full h-8 rounded-md border border-transparent bg-gray-100 p-3 text-right text-sm text-gray-800 placeholder:text-gray-500 disabled:bg-white disabled:pr-0',
+                    invalid &&
+                        'border-red-900 outline-red-900 placeholder:text-red-800',
+                    inputClassName,
+                )}
+            />
+            {invalid && !!errorMessage && (
+                <p
+                    role="alert"
                     className={twMerge(
-                        'h-8 rounded-md',
-                        disabled && 'bg-white p-0',
+                        'text-sm text-red-900',
+                        errorMessageClassName,
                     )}
-                    {...restProps}
-                />
+                >
+                    {errorMessage}
+                </p>
             )}
-        />
+        </label>
     );
-}
+});

--- a/src/rwa/components/table/fee-transactions-table.stories.tsx
+++ b/src/rwa/components/table/fee-transactions-table.stories.tsx
@@ -28,12 +28,16 @@ export const Primary: Story = {
     render: function Wrapper(args) {
         const transaction = mockGroupTransactions[0];
 
-        const { control, register, watch } =
-            useForm<GroupTransactionDetailInputs>({
-                defaultValues: {
-                    fees: transaction.fees,
-                },
-            });
+        const {
+            control,
+            register,
+            watch,
+            formState: { errors },
+        } = useForm<GroupTransactionDetailInputs>({
+            defaultValues: {
+                fees: transaction.fees,
+            },
+        });
 
         const { fields, append, remove } = useFieldArray({
             control,
@@ -49,6 +53,7 @@ export const Primary: Story = {
                     watch={watch}
                     append={append}
                     remove={remove}
+                    errors={errors}
                 />
                 <button
                     onClick={() =>

--- a/src/rwa/components/table/fee-transactions-table.tsx
+++ b/src/rwa/components/table/fee-transactions-table.tsx
@@ -3,8 +3,8 @@ import { ServiceProviderFeeType } from '@/rwa';
 import {
     Control,
     FieldArrayWithId,
+    FieldErrors,
     FieldValues,
-    Path,
     UseFieldArrayAppend,
     UseFieldArrayRemove,
     UseFormRegister,
@@ -22,6 +22,7 @@ type Props<ControlInputs extends FieldValues> = {
     watch: UseFormWatch<GroupTransactionDetailInputs>;
     append: UseFieldArrayAppend<GroupTransactionDetailInputs, 'fees'>;
     remove: UseFieldArrayRemove;
+    errors: FieldErrors<GroupTransactionDetailInputs>;
     isViewOnly: boolean;
 };
 
@@ -37,11 +38,13 @@ export function FeeTransactionsTable<ControlInputs extends FieldValues>(
         }),
     );
 
+    console.log(props.errors.fees?.[0]?.amount?.type);
+
     return (
         <>
             {props.feeInputs.length > 0 && (
                 <div className="bg-gray-50 px-6 pt-3">
-                    <table className="w-full">
+                    <table className="w-full border-separate border-spacing-x-4 border-spacing-y-1">
                         <thead className="mb-2">
                             <tr>
                                 {headings.map(heading => (
@@ -70,8 +73,8 @@ export function FeeTransactionsTable<ControlInputs extends FieldValues>(
 
                                 return (
                                     <tr key={feeInput.id}>
-                                        <td className="w-1/6 py-1"></td>
-                                        <td className="w-4/6 min-w-fit py-1 pr-4">
+                                        <td className=""></td>
+                                        <td className="">
                                             <ServiceProviderAndFeeTypeTableInput
                                                 selectedServiceProviderFeeType={
                                                     selectedServiceProviderFeeType
@@ -84,17 +87,29 @@ export function FeeTransactionsTable<ControlInputs extends FieldValues>(
                                                 control={props.control}
                                             />
                                         </td>
-                                        <td className="w-1/12 py-1 pr-4">
+                                        <td className="w-1/4">
                                             <RWATableTextInput
-                                                name={
-                                                    `fees.${index}.amount` as Path<ControlInputs>
+                                                {...props.register(
+                                                    `fees.${index}.amount`,
+                                                    {
+                                                        required: true,
+                                                        disabled:
+                                                            props.isViewOnly,
+                                                        valueAsNumber: true,
+                                                    },
+                                                )}
+                                                aria-invalid={
+                                                    props.errors.fees?.[index]
+                                                        ?.amount?.type ===
+                                                    'required'
+                                                        ? 'true'
+                                                        : 'false'
                                                 }
-                                                required
-                                                control={props.control}
-                                                disabled={props.isViewOnly}
+                                                type="number"
+                                                placeholder="E.g. 1000"
                                             />
                                         </td>
-                                        <td className="w-fit py-1">
+                                        <td className="">
                                             {!props.isViewOnly && (
                                                 <button
                                                     type="button"

--- a/src/rwa/components/table/fee-transactions-table.tsx
+++ b/src/rwa/components/table/fee-transactions-table.tsx
@@ -38,8 +38,6 @@ export function FeeTransactionsTable<ControlInputs extends FieldValues>(
         }),
     );
 
-    console.log(props.errors.fees?.[0]?.amount?.type);
-
     return (
         <>
             {props.feeInputs.length > 0 && (

--- a/src/rwa/components/table/fixed-income-assets-table.tsx
+++ b/src/rwa/components/table/fixed-income-assets-table.tsx
@@ -174,7 +174,6 @@ export function RWAFixedIncomesTable(props: FixedIncomesTableProps) {
                         onClose={() => setShowNewAssetForm(false)}
                         onCancel={() => setShowNewAssetForm(false)}
                         onSubmitForm={onSubmitCreate}
-                        hideNonEditableFields
                     />
                 </div>
             )}

--- a/src/rwa/components/table/group-transactions-table.tsx
+++ b/src/rwa/components/table/group-transactions-table.tsx
@@ -16,11 +16,11 @@ import { handleDateInTable } from './utils';
 
 export type Fields = {
     id: string;
-    'Entry time': string | undefined;
-    Asset: string | undefined;
-    Quantity: number | undefined;
-    'Cash Amount': number | undefined;
-    'Cash Balance Change': number | undefined;
+    'Entry time': string | undefined | null;
+    Asset: string | undefined | null;
+    Quantity: number | undefined | null;
+    'Cash Amount': number | undefined | null;
+    'Cash Balance Change': number | undefined | null;
 };
 
 export function mapGroupTransactionsToTableFields(
@@ -236,13 +236,13 @@ export function GroupTransactionsTable(props: GroupTransactionsTableProps) {
                             cashTransaction: {
                                 id: '',
                                 assetId: cashAssets[0].id,
-                                amount: 0,
+                                amount: undefined,
                                 counterPartyAccountId: principalLenderAccountId,
                             },
                             fixedIncomeTransaction: {
                                 id: '',
                                 assetId: fixedIncomes[0].id,
-                                amount: 0,
+                                amount: null,
                             },
                         }}
                         fixedIncomes={fixedIncomes}

--- a/src/rwa/types/index.ts
+++ b/src/rwa/types/index.ts
@@ -1,4 +1,4 @@
-import { Maybe, Scalars } from 'document-model/document';
+import { InputMaybe, Maybe, Scalars } from 'document-model/document';
 import {
     groupTransactionTypeLabels,
     groupTransactionTypes,
@@ -54,7 +54,7 @@ export type GroupTransaction = {
 
 export type TransactionFee = {
     id?: Scalars['ID']['output'];
-    amount: Scalars['Float']['output'];
+    amount: InputMaybe<number>;
     serviceProviderFeeTypeId: Scalars['ID']['output'];
 };
 
@@ -67,15 +67,15 @@ export type CashAsset = {
 export type Asset = CashAsset | FixedIncome;
 
 export type BaseTransaction = {
-    id: string;
-    assetId: string;
-    amount: number;
-    entryTime?: string | null;
-    tradeTime?: string | null;
-    settlementTime?: string | null;
-    txRef?: string | null;
-    accountId?: string | null;
-    counterPartyAccountId?: string | null;
+    id: InputMaybe<string>;
+    assetId: InputMaybe<string>;
+    amount: InputMaybe<number>;
+    entryTime?: InputMaybe<string>;
+    tradeTime?: InputMaybe<string>;
+    settlementTime?: InputMaybe<string>;
+    txRef?: InputMaybe<string>;
+    accountId?: InputMaybe<string>;
+    counterPartyAccountId?: InputMaybe<string>;
 };
 
 export type ServiceProviderFeeType = {


### PR DESCRIPTION
the existing text input component for the rwa portfolio tables was based on react-aria. this proved to be quite annoying because:

- its a controlled component, so these inputs cannot be registered with react hook form in the normal way
- they have a non-standard api
- maintaining an error/dirty state requires custom logic

to avoid having to wrangle all of this when adding error messages to the inputs, I refactored the component to instead use a vanilla html <input>. This allows us to have all the same features, while also making it much simpler to use with react hook form.

I've updated the usages of the component to now use the `register` method from react-hook-form and also to include error messages. At the moment I am only showing errors for missing required fields, but this solution can be generalized to any number of validations.

https://github.com/powerhouse-inc/design-system/assets/39741965/d8f96d76-5734-4a4e-87b7-a9f446eadc9a


https://github.com/powerhouse-inc/design-system/assets/39741965/4e329578-d589-4758-ae09-3d6a70b8d3a3

