### PR TITLE
feat: add remaining transaction types

### DIFF
--- a/src/rwa/components/table/transactions/group-transactions-table.stories.tsx
+++ b/src/rwa/components/table/transactions/group-transactions-table.stories.tsx
@@ -32,7 +32,7 @@ export const Empty: Story = {
     args: {
         transactions: [],
         fixedIncomes: [],
-        cashAsset: undefined,
+        cashAsset: mockCashAsset,
         serviceProviderFeeTypes: [],
         principalLenderAccountId: mockPrincipalLenderAccountId,
     },

--- a/src/rwa/constants/transactions.ts
+++ b/src/rwa/constants/transactions.ts
@@ -1,19 +1,29 @@
-export const groupTransactionTypes = [
-    'AssetPurchase',
-    'AssetSale',
-    'InterestDraw',
-    'InterestReturn',
-    'PrincipalDraw',
-    'PrincipalReturn',
-    'FeesPayment',
+export const ASSET_PURCHASE = 'AssetPurchase';
+export const ASSET_SALE = 'AssetSale';
+export const PRINCIPAL_DRAW = 'PrincipalDraw';
+export const PRINCIPAL_RETURN = 'PrincipalReturn';
+export const INTEREST_PAYMENT = 'InterestPayment';
+export const FEES_PAYMENT = 'FeesPayment';
+
+export const principalGroupTransactions = [
+    PRINCIPAL_DRAW,
+    PRINCIPAL_RETURN,
+] as const;
+
+export const assetGroupTransactions = [ASSET_PURCHASE, ASSET_SALE] as const;
+
+export const allGroupTransactionTypes = [
+    ...principalGroupTransactions,
+    ...assetGroupTransactions,
+    INTEREST_PAYMENT,
+    FEES_PAYMENT,
 ] as const;
 
 export const groupTransactionTypeLabels = {
     AssetPurchase: 'Asset purchase',
     AssetSale: 'Asset sale',
-    InterestDraw: 'Interest draw',
-    InterestReturn: 'Interest return',
     PrincipalDraw: 'Principal draw',
     PrincipalReturn: 'Principal return',
+    InterestPayment: 'Interest payment',
     FeesPayment: 'Fees payment',
 } as const;

--- a/src/rwa/mocks/transactions.ts
+++ b/src/rwa/mocks/transactions.ts
@@ -1,5 +1,5 @@
 import { mockFixedIncomes, mockPrincipalLenderAccountId } from '.';
-import { groupTransactionTypes } from '../constants/transactions';
+import { allGroupTransactionTypes } from '../constants/transactions';
 
 export const mockFixedIncomeTransaction = {
     id: 'fixed-income-transaction-1',
@@ -18,7 +18,7 @@ export const mockCashTransaction = {
 
 export const mockGroupTransaction = {
     id: 'group-transaction-0',
-    type: groupTransactionTypes[0],
+    type: allGroupTransactionTypes[0],
     entryTime: '2021-10-01 00:00:00',
     fees: [
         {

--- a/src/rwa/types/index.ts
+++ b/src/rwa/types/index.ts
@@ -1,4 +1,4 @@
-import { groupTransactionTypeLabels, groupTransactionTypes } from '@/rwa';
+import { allGroupTransactionTypes, groupTransactionTypeLabels } from '@/rwa';
 
 export type FixedIncome = {
     // editable fields
@@ -30,7 +30,7 @@ export type SPV = {
     name: string;
 };
 
-export type GroupTransactionType = (typeof groupTransactionTypes)[number];
+export type GroupTransactionType = (typeof allGroupTransactionTypes)[number];
 
 export type GroupTransactionTypeLabel =
     (typeof groupTransactionTypeLabels)[keyof typeof groupTransactionTypeLabels];


### PR DESCRIPTION
— enable all other transaction types (previously was only asset transactions)
— update transaction form fields to adapt to the other transaction types