### PR TITLE
feat: remove buttons when not whitelisted

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,9 @@ const config: StorybookConfig = {
         options: {},
     },
     staticDirs: ['../public'],
+    typescript: {
+        reactDocgen: false,
+    },
     docs: {
         autodocs: 'tag',
     },

--- a/src/connect/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/connect/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -115,6 +115,7 @@ export const Default: Story = {
         return (
             <div className="bg-white p-10">
                 <Breadcrumbs
+                    {...args}
                     filterPath={filterPath}
                     onItemClick={onItemClickHandler}
                     onAddNewItem={onAddNewItemHandler}
@@ -123,5 +124,13 @@ export const Default: Story = {
                 />
             </div>
         );
+    },
+};
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...Default,
+    args: {
+        ...Default.args,
+        isAllowedToCreateDocuments: false,
     },
 };

--- a/src/connect/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/connect/components/breadcrumbs/breadcrumbs.tsx
@@ -12,6 +12,7 @@ export type BreadcrumbsProps = DivProps & {
     onAddNewItem: (basePath: string, option: 'new-folder') => void;
     onSubmitInput: (basepath: string, label: string) => void;
     onCancelInput: (basePath: string) => void;
+    isAllowedToCreateDocuments?: boolean;
 };
 
 /**
@@ -20,6 +21,8 @@ export type BreadcrumbsProps = DivProps & {
  */
 export function Breadcrumbs(props: BreadcrumbsProps) {
     const [isAddingNewItem, setIsAddingNewItem] = useState(false);
+
+    const { isAllowedToCreateDocuments = true } = props;
 
     function onAddNew() {
         setIsAddingNewItem(true);
@@ -40,28 +43,37 @@ export function Breadcrumbs(props: BreadcrumbsProps) {
                     className="transition-colors last-of-type:text-gray-800 hover:text-gray-800"
                 />
             ))}
-            {isAddingNewItem ? (
-                <AddNewItemInput
-                    defaultValue="New Folder"
-                    placeholder="New Folder"
-                    onSubmit={value => {
-                        props.onSubmitInput(props.filterPath, value);
-                        setIsAddingNewItem(false);
-                    }}
-                    onCancel={() => {
-                        props.onCancelInput(props.filterPath);
-                        setIsAddingNewItem(false);
-                    }}
-                />
-            ) : (
-                <button
-                    onClick={onAddNew}
-                    className="ml-1 flex items-center justify-center gap-2 rounded-md bg-gray-50 px-2 py-1.5 transition-colors hover:bg-gray-200 hover:text-gray-800"
-                >
-                    <Icon name="plus" size={14} />
-                    Add new
-                </button>
-            )}
+            <>
+                {isAllowedToCreateDocuments && (
+                    <>
+                        {isAddingNewItem ? (
+                            <AddNewItemInput
+                                defaultValue="New Folder"
+                                placeholder="New Folder"
+                                onSubmit={value => {
+                                    props.onSubmitInput(
+                                        props.filterPath,
+                                        value,
+                                    );
+                                    setIsAddingNewItem(false);
+                                }}
+                                onCancel={() => {
+                                    props.onCancelInput(props.filterPath);
+                                    setIsAddingNewItem(false);
+                                }}
+                            />
+                        ) : (
+                            <button
+                                onClick={onAddNew}
+                                className="ml-1 flex items-center justify-center gap-2 rounded-md bg-gray-50 px-2 py-1.5 transition-colors hover:bg-gray-200 hover:text-gray-800"
+                            >
+                                <Icon name="plus" size={14} />
+                                Add new
+                            </button>
+                        )}
+                    </>
+                )}
+            </>
         </div>
     );
 }
@@ -73,6 +85,7 @@ export type BreadcrumbProps = {
     ) => void;
     filterPath: string;
     className?: string;
+    isAllowedToCreateDocuments?: boolean;
 };
 
 export function Breadcrumb(props: BreadcrumbProps) {

--- a/src/connect/components/drive-view/drive-view.stories.tsx
+++ b/src/connect/components/drive-view/drive-view.stories.tsx
@@ -215,3 +215,11 @@ export const Local: Story = {
     },
     render: args => <DriveViewImpl {...(args as DriveViewProps)} />,
 };
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...Local,
+    args: {
+        ...Local.args,
+        isAllowedToCreateDocuments: false,
+    },
+};

--- a/src/connect/components/drive-view/drive-view.tsx
+++ b/src/connect/components/drive-view/drive-view.tsx
@@ -130,6 +130,7 @@ export function DriveView(props: DriveViewProps) {
                     onItemOptionsClick={onItemOptionsClick}
                     defaultItemOptions={defaultItemOptions}
                     allowedTypes={allowedTypes}
+                    isAllowedToCreateDocuments={isAllowedToCreateDocuments}
                 />
             </div>
             {props.type === 'LOCAL_DRIVE' && isAllowedToCreateDocuments && (

--- a/src/connect/components/drive-view/drive-view.tsx
+++ b/src/connect/components/drive-view/drive-view.tsx
@@ -24,12 +24,14 @@ export interface DriveViewProps
     name: string;
     defaultItemOptions?: ConnectTreeViewItemProps['defaultOptions'];
     drivePath?: string;
+    disableHighlightStyles?: boolean;
+
+    isAllowedToCreateDocuments?: boolean;
     onDropEvent?: ConnectTreeViewProps['onDropEvent'];
     onItemClick?: ConnectTreeViewProps['onItemClick'];
     onSubmitInput?: ConnectTreeViewProps['onSubmitInput'];
     onCancelInput?: ConnectTreeViewProps['onCancelInput'];
     onItemOptionsClick?: ConnectTreeViewProps['onItemOptionsClick'];
-    disableHighlightStyles?: boolean;
     onDropActivate?: ConnectTreeViewProps['onDropActivate'];
     onDragStart?: ConnectTreeViewProps['onDragStart'];
     onDragEnd?: ConnectTreeViewProps['onDragEnd'];
@@ -68,6 +70,7 @@ export function DriveView(props: DriveViewProps) {
         drivePath = '/',
         onCreateDrive,
         disableAddDrives,
+        isAllowedToCreateDocuments = true,
         ...restProps
     } = props;
     const [showAddModal, setShowAddModal] = useState(false);
@@ -98,7 +101,7 @@ export function DriveView(props: DriveViewProps) {
                     {name}
                 </p>
                 <div className="flex gap-1 text-gray-600">
-                    {!disableAddDrives && (
+                    {!disableAddDrives && isAllowedToCreateDocuments && (
                         <button
                             onClick={() => setShowAddModal(true)}
                             className={twMerge(
@@ -129,7 +132,7 @@ export function DriveView(props: DriveViewProps) {
                     allowedTypes={allowedTypes}
                 />
             </div>
-            {props.type === 'LOCAL_DRIVE' && (
+            {props.type === 'LOCAL_DRIVE' && isAllowedToCreateDocuments && (
                 <CreateDriveModal
                     modalProps={{
                         open: showAddModal,
@@ -145,24 +148,26 @@ export function DriveView(props: DriveViewProps) {
                     }}
                 />
             )}
-            {(props.type === 'PUBLIC_DRIVE' ||
-                props.type === 'CLOUD_DRIVE') && (
-                <AddPublicDriveModal
-                    modalProps={{
-                        open: showAddModal,
-                        onOpenChange: setShowAddModal,
-                    }}
-                    formProps={{
-                        sharingType:
-                            props.type === 'PUBLIC_DRIVE' ? 'PUBLIC' : 'SHARED',
-                        onSubmit: data => {
-                            onCreateDrive?.(data);
-                            setShowAddModal(false);
-                        },
-                        onCancel: () => setShowAddModal(false),
-                    }}
-                />
-            )}
+            {(props.type === 'PUBLIC_DRIVE' || props.type === 'CLOUD_DRIVE') &&
+                isAllowedToCreateDocuments && (
+                    <AddPublicDriveModal
+                        modalProps={{
+                            open: showAddModal,
+                            onOpenChange: setShowAddModal,
+                        }}
+                        formProps={{
+                            sharingType:
+                                props.type === 'PUBLIC_DRIVE'
+                                    ? 'PUBLIC'
+                                    : 'SHARED',
+                            onSubmit: data => {
+                                onCreateDrive?.(data);
+                                setShowAddModal(false);
+                            },
+                            onCancel: () => setShowAddModal(false),
+                        }}
+                    />
+                )}
         </div>
     );
 }

--- a/src/connect/components/file-item/file-item.stories.tsx
+++ b/src/connect/components/file-item/file-item.stories.tsx
@@ -47,3 +47,11 @@ export const Default: Story = {
         },
     },
 };
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...Default,
+    args: {
+        ...Default.args,
+        isAllowedToCreateDocuments: false,
+    },
+};

--- a/src/connect/components/file-item/file-item.tsx
+++ b/src/connect/components/file-item/file-item.tsx
@@ -41,6 +41,7 @@ export interface FileItemProps
     icon?: FileItemIconType;
     customIcon?: React.ReactNode;
     itemOptions?: ConnectDropdownMenuProps['items'];
+    isAllowedToCreateDocuments?: boolean;
     onOptionsClick: ConnectDropdownMenuProps['onItemClick'];
     onSubmitInput?: TreeViewInputProps['onSubmitInput'];
     onCancelInput?: TreeViewInputProps['onCancelInput'];
@@ -58,6 +59,7 @@ export const FileItem: React.FC<FileItemProps> = ({
     mode = 'read',
     icon = 'global',
     item,
+    isAllowedToCreateDocuments = true,
     onDragEnd,
     onDragStart,
     onCancelInput = () => {},
@@ -122,7 +124,7 @@ export const FileItem: React.FC<FileItemProps> = ({
                         {content}
                     </div>
                 </div>
-                {isReadMode && (
+                {isReadMode && isAllowedToCreateDocuments && (
                     <div
                         onClick={e => {
                             e.stopPropagation();
@@ -137,19 +139,23 @@ export const FileItem: React.FC<FileItemProps> = ({
                     </div>
                 )}
             </div>
-            <ConnectDropdownMenu
-                isOpen={isDropdownMenuOpen}
-                onOpenChange={() => setIsDropdownMenuOpen(!isDropdownMenuOpen)}
-                items={itemOptions || [...defaultDropdownMenuOptions]}
-                menuClassName="bg-white cursor-pointer"
-                menuItemClassName="hover:bg-slate-50 px-2"
-                onItemClick={onOptionsClick}
-                popoverProps={{
-                    triggerRef: containerRef,
-                    placement: 'bottom end',
-                    offset: -10,
-                }}
-            />
+            {isAllowedToCreateDocuments && (
+                <ConnectDropdownMenu
+                    isOpen={isDropdownMenuOpen}
+                    onOpenChange={() =>
+                        setIsDropdownMenuOpen(!isDropdownMenuOpen)
+                    }
+                    items={itemOptions || [...defaultDropdownMenuOptions]}
+                    menuClassName="bg-white cursor-pointer"
+                    menuItemClassName="hover:bg-slate-50 px-2"
+                    onItemClick={onOptionsClick}
+                    popoverProps={{
+                        triggerRef: containerRef,
+                        placement: 'bottom end',
+                        offset: -10,
+                    }}
+                />
+            )}
         </div>
     );
 };

--- a/src/connect/components/tree-view-item/tree-view-item.stories.tsx
+++ b/src/connect/components/tree-view-item/tree-view-item.stories.tsx
@@ -41,3 +41,11 @@ export const TreeViewItem: Story = {
         },
     },
 };
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...TreeViewItem,
+    args: {
+        ...TreeViewItem.args,
+        isAllowedToCreateDocuments: false,
+    },
+};

--- a/src/connect/components/tree-view-item/tree-view-item.tsx
+++ b/src/connect/components/tree-view-item/tree-view-item.tsx
@@ -45,6 +45,7 @@ export type ConnectTreeViewItemProps = {
     onDragStart?: UseDraggableTargetProps<TreeItem>['onDragStart'];
     onDragEnd?: UseDraggableTargetProps<TreeItem>['onDragEnd'];
     disableHighlightStyles?: boolean;
+    isAllowedToCreateDocuments?: boolean;
 };
 
 export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
@@ -64,6 +65,7 @@ export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
         disableDropBetween = false,
         disableHighlightStyles = false,
         defaultOptions = defaultDropdownMenuOptions,
+        isAllowedToCreateDocuments = true,
         ...divProps
     } = props;
 
@@ -250,7 +252,8 @@ export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
         };
     }
     function statusIconOrDropdownMenuButton() {
-        if (showDropdownMenuButton) return dropdownMenuButton;
+        if (showDropdownMenuButton && isAllowedToCreateDocuments)
+            return dropdownMenuButton;
         if (item.syncStatus && isCloudOrPublicDrive) {
             return (
                 <SyncStatusIcon
@@ -281,20 +284,22 @@ export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
                 {children}
             </TreeViewItem>
             {statusIconOrDropdownMenuButton()}
-            <ConnectDropdownMenu
-                isOpen={isDropdownMenuOpen}
-                onOpenChange={onDropdownMenuOpenChange}
-                items={dropdownMenuItems}
-                menuClassName="bg-white cursor-pointer"
-                menuItemClassName="hover:bg-slate-50 px-2"
-                onItemClick={onItemOptionsClick}
-                popoverProps={{
-                    triggerRef: containerRef,
-                    placement: 'bottom end',
-                    offset: -10,
-                }}
-            />
-            {isDrive && (
+            {isAllowedToCreateDocuments && (
+                <ConnectDropdownMenu
+                    isOpen={isDropdownMenuOpen}
+                    onOpenChange={onDropdownMenuOpenChange}
+                    items={dropdownMenuItems}
+                    menuClassName="bg-white cursor-pointer"
+                    menuItemClassName="hover:bg-slate-50 px-2"
+                    onItemClick={onItemOptionsClick}
+                    popoverProps={{
+                        triggerRef: containerRef,
+                        placement: 'bottom end',
+                        offset: -10,
+                    }}
+                />
+            )}
+            {isDrive && isAllowedToCreateDocuments && (
                 <DriveSettingsModal
                     formProps={{
                         driveName: item.label,

--- a/src/connect/components/tree-view/tree-view.tsx
+++ b/src/connect/components/tree-view/tree-view.tsx
@@ -28,6 +28,7 @@ export interface ConnectTreeViewProps
     level?: number;
     allowedPaths?: string[];
     allowedTypes?: TreeItemType[];
+    isAllowedToCreateDocuments?: boolean;
 }
 
 export function ConnectTreeView(props: ConnectTreeViewProps) {
@@ -42,6 +43,7 @@ export function ConnectTreeView(props: ConnectTreeViewProps) {
         level = 0,
         allowedPaths,
         allowedTypes,
+        isAllowedToCreateDocuments = true,
         ...elementProps
     } = props;
 
@@ -72,6 +74,7 @@ export function ConnectTreeView(props: ConnectTreeViewProps) {
                         defaultOptions={defaultItemOptions}
                         onClick={e => onItemClick?.(e, item)}
                         disableDropBetween={level === 0 && !item.expanded}
+                        isAllowedToCreateDocuments={isAllowedToCreateDocuments}
                         {...elementProps}
                     >
                         {item.expanded && (


### PR DESCRIPTION
pass an `isAllowedToCreateDocuments` variable to components with buttons / options for performing updates. These functions are disabled in the connect app itself, but we want to hide the buttons to avoid confusion.