### PR TITLE
feat: QA updates 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.0.0-alpha.103](https://github.com/powerhouse-inc/design-system/compare/v1.0.0-alpha.102...v1.0.0-alpha.103) (2024-04-29)
+
+
+### Features
+
+* fix collapse style ([05ed9e8](https://github.com/powerhouse-inc/design-system/commit/05ed9e88e1cf93ee1b7f01abdb4553902f159c28))
+
 # [1.0.0-alpha.102](https://github.com/powerhouse-inc/design-system/compare/v1.0.0-alpha.101...v1.0.0-alpha.102) (2024-04-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/design-system",
-  "version": "1.0.0-alpha.102",
+  "version": "1.0.0-alpha.103",
   "description": "",
   "files": [
     "/dist"

--- a/src/connect/components/file-item/__snapshots__/file-item.test.tsx.snap
+++ b/src/connect/components/file-item/__snapshots__/file-item.test.tsx.snap
@@ -28,12 +28,12 @@ exports[`FileItem Component > should match snapshot 1`] = `
           class="overflow-hidden text-gray-800"
         >
           <div
-            class="max-h-6 truncate text-sm font-medium"
+            class="max-h-6 truncate text-sm font-medium group-hover:text-gray-800"
           >
             Legal Contract #1
           </div>
           <div
-            class="max-h-6 truncate text-xs font-medium text-gray-600"
+            class="max-h-6 truncate text-xs font-medium text-gray-600 group-hover:text-gray-800"
           >
             MakerDAO/Ecosystem Actors/Powerhouse/Chronicle Labs/Legal Contract 1
           </div>

--- a/src/connect/components/file-item/file-item.stories.tsx
+++ b/src/connect/components/file-item/file-item.stories.tsx
@@ -31,7 +31,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const ReadMode: Story = {
     args: {
         mode: 'read',
         title: 'Legal Contract #1',
@@ -48,10 +48,18 @@ export const Default: Story = {
     },
 };
 
-export const NotAllowedToCreateDocuments: Story = {
-    ...Default,
+export const WriteMode: Story = {
+    ...ReadMode,
     args: {
-        ...Default.args,
+        ...ReadMode.args,
+        mode: 'write',
+    },
+};
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...ReadMode,
+    args: {
+        ...ReadMode.args,
         isAllowedToCreateDocuments: false,
     },
 };

--- a/src/connect/components/file-item/file-item.tsx
+++ b/src/connect/components/file-item/file-item.tsx
@@ -20,9 +20,6 @@ import {
 import React, { useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-const submitIcon = <Icon name="check" className="text-gray-600" />;
-const cancelIcon = <Icon name="xmark" className="text-gray-600" />;
-
 const iconMap = {
     legal: LegalImg,
     global: GlobalImg,
@@ -103,8 +100,6 @@ export const FileItem: React.FC<FileItemProps> = ({
         <TreeViewInput
             className="ml-3 flex-1 font-medium"
             defaultValue={title}
-            cancelIcon={cancelIcon}
-            submitIcon={submitIcon}
             onCancelInput={onCancelInput}
             onSubmitInput={onSubmitInput}
         />

--- a/src/connect/components/file-item/file-item.tsx
+++ b/src/connect/components/file-item/file-item.tsx
@@ -91,8 +91,10 @@ export const FileItem: React.FC<FileItemProps> = ({
 
     const content = isReadMode ? (
         <>
-            <div className="max-h-6 truncate text-sm font-medium">{title}</div>
-            <div className="max-h-6 truncate text-xs font-medium text-gray-600">
+            <div className="max-h-6 truncate text-sm font-medium group-hover:text-gray-800">
+                {title}
+            </div>
+            <div className="max-h-6 truncate text-xs font-medium text-gray-600 group-hover:text-gray-800">
                 {subTitle}
             </div>
         </>

--- a/src/connect/components/folder-item/__snapshots__/folder-item.test.tsx.snap
+++ b/src/connect/components/folder-item/__snapshots__/folder-item.test.tsx.snap
@@ -25,13 +25,10 @@ exports[`FolderItem Component > should match read snapshot 1`] = `
           </svg>
         </div>
         <div
-          class="ml-3 max-h-6 overflow-hidden whitespace-nowrap font-medium text-slate-200 group-hover:text-gray-800"
+          class="ml-3 max-h-6 truncate font-medium text-slate-200"
         >
           Chronicle Labs
         </div>
-        <div
-          class="absolute right-0 h-full w-12 bg-gradient-to-r from-transparent to-gray-200"
-        />
       </div>
       <div>
         <svg

--- a/src/connect/components/folder-item/__snapshots__/folder-item.test.tsx.snap
+++ b/src/connect/components/folder-item/__snapshots__/folder-item.test.tsx.snap
@@ -90,38 +90,6 @@ exports[`FolderItem Component > should match write snapshot 1`] = `
               value="Chronicle Labs"
             />
           </div>
-          <div
-            class="flex items-center pr-2"
-          >
-            <button
-              class="outline-none"
-              data-rac=""
-              type="button"
-            >
-              <svg
-                class="text-gray-600"
-                style="width: 24px; height: 24px;"
-              >
-                <use
-                  href="icons.svg#xmark"
-                />
-              </svg>
-            </button>
-            <button
-              class="outline-none"
-              data-rac=""
-              type="button"
-            >
-              <svg
-                class="text-gray-600"
-                style="width: 24px; height: 24px;"
-              >
-                <use
-                  href="icons.svg#check"
-                />
-              </svg>
-            </button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/connect/components/folder-item/folder-item.stories.tsx
+++ b/src/connect/components/folder-item/folder-item.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const ReadMode: Story = {
     args: {
         title: 'Chronicle Labs Chronicle Labs Chronicle Labs Chronicle Labs Chronicle Labs Chronicle Labs',
         item: {
@@ -40,10 +40,18 @@ export const Default: Story = {
     },
 };
 
-export const NotAllowedToCreateDocuments: Story = {
-    ...Default,
+export const WriteMode: Story = {
+    ...ReadMode,
     args: {
-        ...Default.args,
+        ...ReadMode.args,
+        mode: 'write',
+    },
+};
+
+export const NotAllowedToCreateDocuments: Story = {
+    ...ReadMode,
+    args: {
+        ...ReadMode.args,
         isAllowedToCreateDocuments: false,
     },
 };

--- a/src/connect/components/folder-item/folder-item.tsx
+++ b/src/connect/components/folder-item/folder-item.tsx
@@ -72,15 +72,9 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     const content =
         isReadMode || !isAllowedToCreateDocuments ? (
             <>
-                <div className="ml-3 max-h-6 overflow-hidden whitespace-nowrap font-medium text-slate-200 group-hover:text-gray-800">
+                <div className="ml-3 max-h-6 truncate font-medium text-slate-200">
                     {title}
                 </div>
-                <div
-                    className={twMerge(
-                        'absolute right-0 h-full w-12 bg-gradient-to-r from-transparent to-gray-200',
-                        isDropTarget && 'to-blue-100',
-                    )}
-                />
             </>
         ) : (
             <TreeViewInput

--- a/src/connect/components/folder-item/folder-item.tsx
+++ b/src/connect/components/folder-item/folder-item.tsx
@@ -17,9 +17,6 @@ import {
 import React, { useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-const submitIcon = <Icon name="check" className="text-gray-600" />;
-const cancelIcon = <Icon name="xmark" className="text-gray-600" />;
-
 type FolderItem = object;
 
 export interface FolderItemProps
@@ -89,8 +86,6 @@ export const FolderItem: React.FC<FolderItemProps> = ({
             <TreeViewInput
                 className="ml-3 flex-1 font-medium"
                 defaultValue={title}
-                cancelIcon={cancelIcon}
-                submitIcon={submitIcon}
                 onCancelInput={onCancelInput}
                 onSubmitInput={onSubmitInput}
             />

--- a/src/connect/components/form-input/form-input.stories.tsx
+++ b/src/connect/components/form-input/form-input.stories.tsx
@@ -13,6 +13,7 @@ type Story = StoryObj<typeof meta>;
 
 const Template: Story = {
     args: {
+        name: 'driveName',
         icon: <Icon name="drive" />,
         placeholder: 'Enter value',
     },
@@ -69,19 +70,6 @@ export const WithRegexPattern: Story = {
     args: {
         ...Template.args,
         pattern: '[a-c]{3}',
-    },
-};
-
-export const WithCustomErrorMessage: Story = {
-    ...Template,
-    args: {
-        ...Template.args,
-        required: true,
-        customErrorMessages: {
-            valueMissing: (
-                <span className="text-purple-900">This field is required</span>
-            ),
-        },
     },
 };
 

--- a/src/connect/components/form-input/form-input.tsx
+++ b/src/connect/components/form-input/form-input.tsx
@@ -1,29 +1,16 @@
-import {
-    ChangeEventHandler,
-    ComponentPropsWithRef,
-    FocusEventHandler,
-    ForwardedRef,
-    forwardRef,
-    useCallback,
-    useEffect,
-    useState,
-} from 'react';
+import { ComponentPropsWithRef, ForwardedRef, forwardRef } from 'react';
 import { twJoin, twMerge } from 'tailwind-merge';
+
 type InputProps = ComponentPropsWithRef<'input'>;
 type FormInputProps = Omit<InputProps, 'className'> & {
     icon: React.JSX.Element;
+    errorMessage?: string;
+    isTouched?: boolean;
+    isDirty?: boolean;
     type?: 'text' | 'password' | 'email' | 'url';
     inputClassName?: string;
     containerClassName?: string;
-    customErrorMessages?: {
-        patternMismatch?: React.ReactNode;
-        tooLong?: React.ReactNode;
-        tooShort?: React.ReactNode;
-        typeMismatch?: React.ReactNode;
-        valueMissing?: React.ReactNode;
-    };
-    errorOverride?: React.ReactNode;
-    onError?: (error?: React.ReactNode) => void;
+    errorMessageClassName?: string;
     hideErrors?: boolean;
 };
 export const FormInput = forwardRef(function FormInput(
@@ -32,78 +19,18 @@ export const FormInput = forwardRef(function FormInput(
 ) {
     const {
         icon,
+        name,
+        errorMessage,
+        isDirty,
+        isTouched,
         containerClassName,
         inputClassName,
-        errorOverride,
-        onError,
+        errorMessageClassName,
         hideErrors = false,
         ...delegatedProps
     } = props;
-
-    const [dirty, setDirty] = useState(props.value !== '');
-    const [error, setError] = useState<React.ReactNode>(errorOverride ?? '');
-    const isError = error !== '';
     const type = props.type ?? 'text';
-
-    const onErrorCallback = useCallback(
-        (error: React.ReactNode) => onError?.(error),
-        [onError],
-    );
-
-    useEffect(() => {
-        if (errorOverride) {
-            setError(errorOverride);
-        }
-    }, [errorOverride]);
-
-    useEffect(() => {
-        if (isError) {
-            onErrorCallback(error);
-        }
-    }, [error, isError, onErrorCallback]);
-
-    const onBlur: FocusEventHandler<HTMLInputElement> = e => {
-        const { validity, value } = e.currentTarget;
-        const {
-            patternMismatch,
-            tooLong,
-            tooShort,
-            typeMismatch,
-            valueMissing,
-        } = validity;
-
-        if (value !== '') {
-            setDirty(true);
-        }
-
-        if (patternMismatch) {
-            setError('Please match the requested format');
-        } else if (tooLong) {
-            setError(props.customErrorMessages?.tooLong ?? 'Too long');
-        } else if (tooShort) {
-            setError(props.customErrorMessages?.tooShort ?? 'Too short');
-        } else if (typeMismatch) {
-            setError(
-                props.customErrorMessages?.typeMismatch ??
-                    'Please enter a valid email address',
-            );
-        } else if (valueMissing) {
-            setError(
-                props.customErrorMessages?.valueMissing ?? 'Cannot be empty',
-            );
-        } else {
-            setError('');
-        }
-        props.onBlur?.(e);
-    };
-
-    const onChange: ChangeEventHandler<HTMLInputElement> = e => {
-        if (e.currentTarget.value !== '') {
-            setError('');
-        }
-        props.onChange?.(e);
-    };
-
+    const isError = !!errorMessage;
     return (
         <div>
             <div
@@ -114,15 +41,15 @@ export const FormInput = forwardRef(function FormInput(
                 )}
             >
                 <span
-                    className={twJoin((!dirty || isError) && 'text-slate-200')}
+                    className={twJoin(
+                        (!isDirty || isError) && 'text-slate-200',
+                    )}
                 >
                     {icon}
                 </span>
                 <input
                     {...delegatedProps}
                     type={type}
-                    onBlur={onBlur}
-                    onChange={onChange}
                     ref={ref}
                     className={twMerge(
                         'w-full bg-transparent font-semibold outline-none',
@@ -137,7 +64,7 @@ export const FormInput = forwardRef(function FormInput(
                     hideErrors && 'hidden',
                 )}
             >
-                {error}
+                {errorMessage}
             </p>
         </div>
     );

--- a/src/connect/components/form-input/form-input.tsx
+++ b/src/connect/components/form-input/form-input.tsx
@@ -132,8 +132,8 @@ export const FormInput = forwardRef(function FormInput(
             </div>
             <p
                 className={twMerge(
-                    'invisible min-h-[16px] text-xs text-red-900',
-                    isError && 'visible',
+                    'hidden min-h-4 text-xs text-red-900',
+                    isError && 'block',
                     hideErrors && 'hidden',
                 )}
             >

--- a/src/connect/components/form/add-public-drive-form.tsx
+++ b/src/connect/components/form/add-public-drive-form.tsx
@@ -12,7 +12,7 @@ import { Button, Icon } from '@/powerhouse';
 import { requestPublicDrive } from 'document-drive/utils/graphql';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useDebounce } from 'usehooks-ts';
+import { useDebounceValue } from 'usehooks-ts';
 
 interface PublicDriveDetails extends AddDriveInput {
     id: string;
@@ -36,28 +36,27 @@ type AddPublicDriveFormProps = {
 
 export function AddPublicDriveForm(props: AddPublicDriveFormProps) {
     const { sharingType = 'PUBLIC' } = props;
-    const [url, setUrl] = useState('');
     const [publicDriveDetails, setPublicDriveDetails] =
         useState<PublicDriveDetails>();
     const [showLocationSettings, setShowLocationSettings] = useState(false);
     const [isUrlValid, setIsUrlValid] = useState(true);
     const [hasConfirmedUrl, setHasConfirmedUrl] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
-    const debouncedUrl = useDebounce(url, 500);
+    const [url, setUrl] = useDebounceValue('', 500);
     const { register, handleSubmit, setValue } = useForm<Inputs>({
+        mode: 'onBlur',
         defaultValues: {
             availableOffline: publicDriveDetails?.availableOffline ?? false,
         },
     });
-
     useEffect(() => {
         setHasConfirmedUrl(false);
-        if (debouncedUrl === '') return;
+        if (url === '') return;
         fetchPublicDrive().catch(console.error);
 
         async function fetchPublicDrive() {
             try {
-                const { id, name } = await requestPublicDrive(debouncedUrl);
+                const { id, name } = await requestPublicDrive(url);
                 setPublicDriveDetails({
                     id,
                     driveName: name,
@@ -74,7 +73,7 @@ export function AddPublicDriveForm(props: AddPublicDriveFormProps) {
                 setErrorMessage((error as Error).message);
             }
         }
-    }, [debouncedUrl, setValue]);
+    }, [url, setValue]);
 
     function onSubmit({ availableOffline }: Inputs) {
         if (!publicDriveDetails) return;

--- a/src/connect/components/form/add-public-drive-form.tsx
+++ b/src/connect/components/form/add-public-drive-form.tsx
@@ -73,7 +73,7 @@ export function AddPublicDriveForm(props: AddPublicDriveFormProps) {
                 setErrorMessage((error as Error).message);
             }
         }
-    }, [url, setValue]);
+    }, [url, setValue, sharingType]);
 
     function onSubmit({ availableOffline }: Inputs) {
         if (!publicDriveDetails) return;
@@ -115,7 +115,7 @@ export function AddPublicDriveForm(props: AddPublicDriveFormProps) {
                         placeholder="Drive URL"
                         required
                         onChange={e => setUrl(e.target.value)}
-                        errorOverride={errorMessage}
+                        errorMessage={errorMessage}
                     />
                     <Divider className="mb-3" />
                     <Button

--- a/src/connect/components/form/create-drive-form.tsx
+++ b/src/connect/components/form/create-drive-form.tsx
@@ -34,6 +34,7 @@ export function CreateDriveForm(props: CreateDriveFormProps) {
     const [showLocationSettings, setShowLocationSettings] = useState(false);
     const [showUpload, setShowUpload] = useState(false);
     const { register, handleSubmit, control } = useForm<Inputs>({
+        mode: 'onBlur',
         defaultValues: {
             driveName: '',
             sharingType: 'PRIVATE',
@@ -46,7 +47,7 @@ export function CreateDriveForm(props: CreateDriveFormProps) {
         <form onSubmit={handleSubmit(props.onSubmit)}>
             <Label htmlFor="driveName">Drive Name</Label>
             <DriveNameInput {...register('driveName')} />
-            <Divider className="mb-[18px] mt-4" />
+            <Divider className="my-4" />
             <Label htmlFor="sharingType">Sharing settings</Label>
             <SharingTypeFormInput control={control} />
             <Divider className="my-3" />

--- a/src/connect/components/form/create-drive-form.tsx
+++ b/src/connect/components/form/create-drive-form.tsx
@@ -3,7 +3,7 @@ import {
     Disclosure,
     Divider,
     DriveLocation,
-    DriveNameInput,
+    FormInput,
     Label,
     LocationInfo,
     SharingType,
@@ -33,10 +33,13 @@ export type AddDriveInput = Inputs;
 export function CreateDriveForm(props: CreateDriveFormProps) {
     const [showLocationSettings, setShowLocationSettings] = useState(false);
     const [showUpload, setShowUpload] = useState(false);
-    const { register, handleSubmit, control } = useForm<Inputs>({
-        mode: 'onBlur',
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+    } = useForm<Inputs>({
         defaultValues: {
-            driveName: '',
             sharingType: 'PRIVATE',
             availableOffline: false,
             location: props.location,
@@ -46,7 +49,14 @@ export function CreateDriveForm(props: CreateDriveFormProps) {
     return (
         <form onSubmit={handleSubmit(props.onSubmit)}>
             <Label htmlFor="driveName">Drive Name</Label>
-            <DriveNameInput {...register('driveName')} />
+            <FormInput
+                {...register('driveName', {
+                    required: 'Drive name is required',
+                })}
+                errorMessage={errors.driveName?.message}
+                icon={<Icon name="drive" />}
+                placeholder="Drive name"
+            />
             <Divider className="my-4" />
             <Label htmlFor="sharingType">Sharing settings</Label>
             <SharingTypeFormInput control={control} />

--- a/src/connect/components/form/drive-settings-form.tsx
+++ b/src/connect/components/form/drive-settings-form.tsx
@@ -39,6 +39,7 @@ export function DriveSettingsForm(props: DriveSettingsFormProps) {
     const hasDriveIcon = Boolean(driveIcon);
     const optionalDriveIconField = hasDriveIcon ? { driveIcon } : {};
     const { register, handleSubmit, control } = useForm<Inputs>({
+        mode: 'onBlur',
         defaultValues: {
             driveName: props.driveName,
             sharingType: props.sharingType,
@@ -50,7 +51,7 @@ export function DriveSettingsForm(props: DriveSettingsFormProps) {
     return (
         <form onSubmit={handleSubmit(props.onSubmit)}>
             <DriveNameInput {...register('driveName')} />
-            <Divider className="mb-[18px] mt-4" />
+            <Divider className="my-4" />
             <Label htmlFor="sharingType">Sharing settings</Label>
             <SharingTypeFormInput control={control} />
             {hasDriveIcon && (

--- a/src/connect/components/form/inputs/drive-name-input.tsx
+++ b/src/connect/components/form/inputs/drive-name-input.tsx
@@ -19,6 +19,7 @@ export const DriveNameInput = forwardRef(function DriveNameInput(
             ref={ref}
             icon={props.icon ?? <Icon name="drive" />}
             id="driveName"
+            placeholder="Drive name"
             required
         />
     );

--- a/src/connect/components/form/inputs/drive-name-input.tsx
+++ b/src/connect/components/form/inputs/drive-name-input.tsx
@@ -4,7 +4,7 @@ import { ComponentPropsWithRef, ForwardedRef, forwardRef } from 'react';
 
 type DriveNameInputProps = Omit<
     ComponentPropsWithRef<typeof FormInput>,
-    'icon' | 'id' | 'required'
+    'icon' | 'id'
 > & {
     icon?: React.JSX.Element;
 };
@@ -20,7 +20,6 @@ export const DriveNameInput = forwardRef(function DriveNameInput(
             icon={props.icon ?? <Icon name="drive" />}
             id="driveName"
             placeholder="Drive name"
-            required
         />
     );
 });

--- a/src/connect/components/modal/add-public-drive-modal.tsx
+++ b/src/connect/components/modal/add-public-drive-modal.tsx
@@ -1,5 +1,5 @@
 import { AddPublicDriveForm, Divider } from '@/connect';
-import { DivProps, Modal } from '@/powerhouse';
+import { DivProps, Icon, Modal } from '@/powerhouse';
 import { ComponentPropsWithoutRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -29,8 +29,17 @@ export function AddPublicDriveModal(props: AddPublicDriveModalProps) {
                     props.containerProps?.className,
                 )}
             >
-                <h1 className="text-xl font-bold">Add drive</h1>
-                <Divider className="mb-[18px] mt-4" />
+                <div className="flex justify-between">
+                    <h1 className="text-xl font-bold">Add drive</h1>
+                    <button
+                        className="flex size-8 items-center justify-center rounded-md bg-gray-100 text-gray-500 outline-none hover:text-gray-900"
+                        onClick={() => props.modalProps?.onOpenChange?.(false)}
+                        tabIndex={-1}
+                    >
+                        <Icon name="xmark-light" size={24} />
+                    </button>
+                </div>
+                <Divider className="my-4" />
                 <AddPublicDriveForm
                     {...props.formProps}
                     onCancel={handleCancel}

--- a/src/connect/components/modal/create-drive-modal.tsx
+++ b/src/connect/components/modal/create-drive-modal.tsx
@@ -1,5 +1,5 @@
 import { CreateDriveForm, Divider } from '@/connect';
-import { DivProps, Modal } from '@/powerhouse';
+import { DivProps, Icon, Modal } from '@/powerhouse';
 import { ComponentPropsWithoutRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -29,8 +29,17 @@ export function CreateDriveModal(props: CreateDriveModalProps) {
                     props.containerProps?.className,
                 )}
             >
-                <h1 className="text-xl font-bold">Create new drive</h1>
-                <Divider className="mb-[18px] mt-4" />
+                <div className="flex justify-between">
+                    <h1 className="text-xl font-bold">Create new drive </h1>
+                    <button
+                        className="flex size-8 items-center justify-center rounded-md bg-gray-100 text-gray-500 outline-none hover:text-gray-900"
+                        onClick={() => props.modalProps?.onOpenChange?.(false)}
+                        tabIndex={-1}
+                    >
+                        <Icon name="xmark-light" size={24} />
+                    </button>
+                </div>
+                <Divider className="my-4" />
                 <CreateDriveForm {...props.formProps} onCancel={handleCancel} />
             </div>
         </Modal>

--- a/src/connect/components/modal/drive-settings-modal.tsx
+++ b/src/connect/components/modal/drive-settings-modal.tsx
@@ -1,5 +1,5 @@
 import { Divider, DriveSettingsForm } from '@/connect';
-import { DivProps, Modal } from '@/powerhouse';
+import { DivProps, Icon, Modal } from '@/powerhouse';
 import { ComponentPropsWithoutRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -33,8 +33,17 @@ export function DriveSettingsModal(props: DriveSettingsModalProps) {
                     props.containerProps?.className,
                 )}
             >
-                <h1 className="text-xl font-bold">Drive Settings</h1>
-                <Divider className="mb-[18px] mt-4" />
+                <div className="flex justify-between">
+                    <h1 className="text-xl font-bold">Drive settings</h1>
+                    <button
+                        className="flex size-8 items-center justify-center rounded-md bg-gray-100 text-gray-500 outline-none hover:text-gray-900"
+                        onClick={() => props.modalProps?.onOpenChange?.(false)}
+                        tabIndex={-1}
+                    >
+                        <Icon name="xmark-light" size={24} />
+                    </button>
+                </div>
+                <Divider className="my-4" />
                 <DriveSettingsForm
                     {...props.formProps}
                     onDeleteDrive={handleDeleteDrive}

--- a/src/connect/components/sidebar/sidebar-login.tsx
+++ b/src/connect/components/sidebar/sidebar-login.tsx
@@ -11,7 +11,7 @@ export const SidebarLogin: React.FC<SidebarLoginProps> = ({ onLogin }) => {
         <>
             {/* full-size version for expanded */}
             <button
-                className="group/sidebar-footer flex w-full cursor-pointer items-baseline justify-start text-sm font-semibold leading-10 text-gray-600 collapsed:hidden expanded:block"
+                className="group/sidebar-footer hidden w-full cursor-pointer items-baseline justify-start text-sm font-semibold leading-10 text-gray-600 expanded:flex"
                 onClick={onLogin}
             >
                 <span>Login with</span>
@@ -26,7 +26,7 @@ export const SidebarLogin: React.FC<SidebarLoginProps> = ({ onLogin }) => {
             </button>
             {/* small version for collapsed */}
             <button
-                className="group/sidebar-footer grid w-full cursor-pointer place-items-center p-1 collapsed:block expanded:hidden"
+                className="group/sidebar-footer hidden w-full cursor-pointer place-items-center p-1 collapsed:grid"
                 onClick={onLogin}
                 aria-label="Login with Renown"
             >

--- a/src/connect/components/tree-view-item/tree-view-item.tsx
+++ b/src/connect/components/tree-view-item/tree-view-item.tsx
@@ -29,9 +29,6 @@ import {
 } from '../drive-view/utils';
 import { SyncStatusIcon } from '../status-icon';
 
-const submitIcon = <Icon name="check" className="text-gray-600" />;
-const cancelIcon = <Icon name="xmark" className="text-gray-600" />;
-
 export type ConnectTreeViewItemProps = {
     item: TreeItem;
     children: React.ReactNode;
@@ -270,7 +267,7 @@ export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
         itemContainerClassNameOverrides?: string,
     ) {
         const commonStyles =
-            'group/item rounded-lg py-3 transition-colors text-gray-800';
+            'group/item rounded-lg py-3 pr-4 transition-colors text-gray-800';
         const publicDriveHighlightStyles = 'bg-gray-300 text-gray-900';
         const otherHighlightStyles = 'bg-slate-50 text-gray-900';
         const highlightStyles = isChildOfPublicDrive
@@ -330,8 +327,6 @@ export function ConnectTreeViewItem(props: ConnectTreeViewItemProps) {
                 label={item.label}
                 open={item.expanded}
                 itemContainerProps={getItemContainerProps()}
-                submitIcon={submitIcon}
-                cancelIcon={cancelIcon}
                 {...getItemIcon()}
                 {...divProps}
             >

--- a/src/connect/components/tree-view/tree-view.stories.tsx
+++ b/src/connect/components/tree-view/tree-view.stories.tsx
@@ -152,7 +152,7 @@ const TreeViewImpl = (args: ConnectTreeViewProps) => {
     };
 
     return (
-        <div className="bg-white p-10">
+        <div className="max-w-[304px] bg-white p-10">
             <ConnectTreeView
                 onItemClick={onItemClickHandler}
                 onCancelInput={onCancelInputHandler}

--- a/src/connect/utils/mocks/tree-item.ts
+++ b/src/connect/utils/mocks/tree-item.ts
@@ -71,7 +71,7 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
         {
             id: randomId(),
             path: `${drive}/folder3`,
-            label: 'Folder 3',
+            label: 'Folder 3 Folder 3 Folder 3 Folder 3 Folder 3',
             type: 'FOLDER',
             availableOffline: false,
             syncStatus: 'SYNCING',

--- a/src/powerhouse/components/tree-view-input/__snapshots__/tree-view-input.test.tsx.snap
+++ b/src/powerhouse/components/tree-view-input/__snapshots__/tree-view-input.test.tsx.snap
@@ -21,28 +21,6 @@ exports[`TreeViewInput Component > should match snapshot 1`] = `
         value="My Documents"
       />
     </div>
-    <div
-      class="flex items-center pr-2"
-    >
-      <button
-        class="outline-none"
-        data-rac=""
-        type="button"
-      >
-        <div>
-          cancel
-        </div>
-      </button>
-      <button
-        class="outline-none"
-        data-rac=""
-        type="button"
-      >
-        <div>
-          submit
-        </div>
-      </button>
-    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/powerhouse/components/tree-view-input/tree-view-input.stories.tsx
+++ b/src/powerhouse/components/tree-view-input/tree-view-input.stories.tsx
@@ -1,9 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Icon } from '..';
 import { TreeViewInput } from './tree-view-input';
-
-const submitIcon = <Icon name="check" className="text-gray-600" />;
-const cancelIcon = <Icon name="xmark" className="text-gray-600" />;
 
 const meta: Meta<typeof TreeViewInput> = {
     title: 'Powerhouse/Components/TreeView/TreeViewInput',
@@ -15,8 +11,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
     args: {
-        submitIcon,
-        cancelIcon,
         defaultValue:
             'My Documents lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.',
         placeholder: 'Folder Name',

--- a/src/powerhouse/components/tree-view-input/tree-view-input.test.tsx
+++ b/src/powerhouse/components/tree-view-input/tree-view-input.test.tsx
@@ -5,20 +5,22 @@ import { TreeViewInput } from './tree-view-input';
 describe('TreeViewInput Component', () => {
     let onSubmitInput: Mock;
     let onCancelInput: Mock;
+    let input: HTMLInputElement;
+    Object.defineProperty(window.Element.prototype, 'scroll', {
+        writable: true,
+        value: vitest.fn(),
+    });
 
     const props = {
         level: 0,
         'aria-label': 'input',
         icon: 'Icon',
         defaultValue: 'My Documents',
-        submitIcon: <div>submit</div>,
-        cancelIcon: <div>cancel</div>,
     };
 
     beforeEach(() => {
         onSubmitInput = vi.fn();
         onCancelInput = vi.fn();
-
         render(
             <TreeViewInput
                 {...props}
@@ -26,6 +28,7 @@ describe('TreeViewInput Component', () => {
                 onCancelInput={onCancelInput}
             />,
         );
+        input = screen.getByLabelText('input');
     });
 
     it('should match snapshot', () => {
@@ -35,8 +38,6 @@ describe('TreeViewInput Component', () => {
                 onSubmitInput={() => {}}
                 onCancelInput={() => {}}
                 defaultValue="My Documents"
-                submitIcon={<div>submit</div>}
-                cancelIcon={<div>cancel</div>}
             />,
         );
 
@@ -47,18 +48,12 @@ describe('TreeViewInput Component', () => {
         expect(
             screen.getByDisplayValue(props.defaultValue),
         ).toBeInTheDocument();
-        expect(screen.getByText('submit')).toBeInTheDocument();
-        expect(screen.getByText('cancel')).toBeInTheDocument();
-    });
 
-    it('should call onSubmitInput when click submit icon', () => {
-        fireEvent.click(screen.getByText('submit'));
-
-        expect(onSubmitInput).toHaveBeenCalled();
+        expect(input).toBeInTheDocument();
     });
 
     it('should call onSubmitInput when press enter key', () => {
-        fireEvent.keyUp(screen.getByLabelText('input'), {
+        fireEvent.keyUp(input, {
             key: 'Enter',
         });
 
@@ -66,7 +61,7 @@ describe('TreeViewInput Component', () => {
     });
 
     it('should call onSubmitInput when click outside', async () => {
-        await waitFor(() => screen.getByText('submit'), {
+        await waitFor(() => input, {
             timeout: 100,
         });
         fireEvent.click(document.body);
@@ -74,14 +69,8 @@ describe('TreeViewInput Component', () => {
         expect(onSubmitInput).toHaveBeenCalled();
     });
 
-    it('should call onCancelInput when click cancel icon', () => {
-        fireEvent.click(screen.getByText('cancel'));
-
-        expect(onCancelInput).toHaveBeenCalled();
-    });
-
     it('should call onCancelInput when press Esc key', () => {
-        fireEvent.keyUp(screen.getByLabelText('input'), {
+        fireEvent.keyUp(input, {
             key: 'Escape',
         });
 
@@ -89,14 +78,13 @@ describe('TreeViewInput Component', () => {
     });
 
     it('should call onSubmitInput with text value', () => {
-        fireEvent.change(screen.getByLabelText('input'), {
+        fireEvent.change(input, {
             target: { value: 'new value' },
         });
 
-        fireEvent.click(screen.getByText('submit'));
-        expect(onSubmitInput).toHaveBeenCalledWith(
-            'new value',
-            expect.anything(),
-        );
+        fireEvent.keyUp(input, {
+            key: 'Enter',
+        });
+        expect(onSubmitInput).toHaveBeenCalledWith('new value');
     });
 });

--- a/src/powerhouse/components/tree-view-input/tree-view-input.tsx
+++ b/src/powerhouse/components/tree-view-input/tree-view-input.tsx
@@ -5,22 +5,18 @@ import {
     useState,
 } from 'react';
 import { useKeyboard } from 'react-aria';
-import { Button, Input, PressEvent, TextField } from 'react-aria-components';
+import { Input, PressEvent, TextField } from 'react-aria-components';
 import ClickAwayListener from 'react-click-away-listener';
 import { twMerge } from 'tailwind-merge';
 
 export interface TreeViewInputProps
     extends Omit<ComponentPropsWithoutRef<'input'>, 'onSubmit'> {
-    cancelIcon?: React.JSX.Element;
-    submitIcon?: React.JSX.Element;
     onCancelInput?: () => void;
     onSubmitInput?: (value: string, event?: PressEvent) => void;
 }
 
 export const TreeViewInput: React.FC<TreeViewInputProps> = props => {
     const {
-        submitIcon,
-        cancelIcon,
         onSubmitInput,
         onCancelInput,
         className,
@@ -37,7 +33,9 @@ export const TreeViewInput: React.FC<TreeViewInputProps> = props => {
     useLayoutEffect(() => {
         setTimeout(() => {
             inputRef.current?.focus();
-        }, 500);
+            inputRef.current?.select();
+            inputRef.current?.scroll({ left: 9999 });
+        }, 100);
     }, []);
 
     const { keyboardProps } = useKeyboard({
@@ -74,17 +72,6 @@ export const TreeViewInput: React.FC<TreeViewInputProps> = props => {
                         ref={inputRef}
                     />
                 </TextField>
-                <div className="flex items-center pr-2">
-                    <Button className="outline-none" onPress={onCancelInput}>
-                        {cancelIcon}
-                    </Button>
-                    <Button
-                        onPress={e => onSubmitInput?.(text, e)}
-                        className="outline-none"
-                    >
-                        {submitIcon}
-                    </Button>
-                </div>
             </div>
         </ClickAwayListener>
     );

--- a/src/powerhouse/components/tree-view-item/tree-view-item.tsx
+++ b/src/powerhouse/components/tree-view-item/tree-view-item.tsx
@@ -87,7 +87,7 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
                             {open ? expandedIcon || icon : icon}
                         </span>
                     )}
-                    <div className="w-full cursor-pointer truncate hover:overflow-x-scroll hover:text-clip">
+                    <div className="w-full cursor-pointer truncate">
                         {content}
                     </div>
                 </div>

--- a/src/powerhouse/components/tree-view-item/tree-view-item.tsx
+++ b/src/powerhouse/components/tree-view-item/tree-view-item.tsx
@@ -29,8 +29,6 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
         children,
         icon,
         expandedIcon,
-        submitIcon,
-        cancelIcon,
         topIndicator,
         bottomIndicator,
         level = 0,
@@ -50,8 +48,6 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
         defaultValue: label,
         onSubmitInput,
         onCancelInput,
-        submitIcon,
-        cancelIcon,
     };
 
     const content = mode === 'read' ? label : <TreeViewInput {...inputProps} />;
@@ -91,8 +87,7 @@ export const TreeViewItem: React.FC<TreeViewItemProps> = props => {
                             {open ? expandedIcon || icon : icon}
                         </span>
                     )}
-                    <div className="relative w-full overflow-hidden whitespace-nowrap">
-                        <span className="absolute right-0 h-full w-12 bg-gradient-to-r from-transparent to-inherit" />
+                    <div className="w-full cursor-pointer truncate hover:overflow-x-scroll hover:text-clip">
                         {content}
                     </div>
                 </div>


### PR DESCRIPTION
[Address remaining design feedback found here ](https://www.notion.so/makerdao-ses/QA-test-Connect-RWA-37b0a6e9068a49d2ae186a32c34309a8)

- remove "submit" and "cancel" buttons from inputs, they take up a lot of space and not commonly found in other file system type apps
- always truncate names with ellipsis when they are too long
<img width="437" alt="Screenshot 2024-05-01 at 10 20 23" src="https://github.com/powerhouse-inc/design-system/assets/39741965/14b3a18e-f8a1-4794-93ba-f1d3de60f1ba">
- when renaming items, highlight the full text as is done in other apps
<img width="241" alt="Screenshot 2024-05-01 at 10 20 53" src="https://github.com/powerhouse-inc/design-system/assets/39741965/303a7b2e-4358-46df-a5e0-4d1748b4ccd3">
- when closing modals without interacting, do not show the "cannot be empty" error message
- for modals that do not have a "cancel" button, add a close button to the top right of the modal
<img width="405" alt="Screenshot 2024-05-01 at 10 21 59" src="https://github.com/powerhouse-inc/design-system/assets/39741965/9bfc34bd-5a0d-4882-bea8-0810642f0c43">
- handle some inconsistent spacing in forms