### PR TITLE
feat: qa updates 5

### DIFF
--- a/src/connect/components/combobox/combobox.tsx
+++ b/src/connect/components/combobox/combobox.tsx
@@ -58,8 +58,8 @@ function MenuList(
 }
 
 export function Combobox(props: Props) {
+    const invalid = props['aria-invalid'] === 'true';
     const { addItemButtonProps, ...rest } = props;
-
     return (
         <Select
             {...rest}
@@ -93,6 +93,12 @@ export function Combobox(props: Props) {
                         fontSize: 12,
                     };
                 },
+                placeholder: baseStyles => {
+                    return {
+                        ...baseStyles,
+                        color: invalid ? 'var(--red-800)' : 'var(--gray-500)',
+                    };
+                },
                 control: () => {
                     return {
                         label: 'control',
@@ -106,7 +112,9 @@ export function Combobox(props: Props) {
                         position: 'relative',
                         transition: 'all 100ms',
                         backgroundColor: 'var(--white)',
-                        borderColor: 'var(--gray-200)',
+                        borderColor: invalid
+                            ? 'var(--red-900)'
+                            : 'var(--gray-200)',
                         borderStyle: 'solid',
                         borderWidth: 1,
                         borderRadius: '6px',

--- a/src/globals.css
+++ b/src/globals.css
@@ -237,5 +237,5 @@ h4,
 h5,
 h6,
 p {
-    color: var(--red-900);
+    color: var(--gray-900);
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -237,5 +237,5 @@ h4,
 h5,
 h6,
 p {
-    color: var(--gray-900);
+    color: var(--red-900);
 }

--- a/src/rwa/components/inputs/select.tsx
+++ b/src/rwa/components/inputs/select.tsx
@@ -1,16 +1,25 @@
 import { Combobox } from '@/connect/components/combobox';
 import { ComponentPropsWithoutRef } from 'react';
-import { Control, Controller, FieldValues, Path } from 'react-hook-form';
+import {
+    Control,
+    Controller,
+    FieldValues,
+    Path,
+    ValidationRule,
+} from 'react-hook-form';
+import { twMerge } from 'tailwind-merge';
 
 export type RWATableSelectProps<ControlInputs extends FieldValues> = Omit<
     ComponentPropsWithoutRef<typeof Combobox>,
-    'options'
+    'options' | 'required'
 > & {
     options: { label: string; value: string }[];
     disabled?: boolean;
     name: Path<ControlInputs>;
     control: Control<ControlInputs>;
-    required?: boolean;
+    required?: string | ValidationRule<boolean> | undefined;
+    errorMessage?: string;
+    errorMessageClassName?: string;
 };
 
 export function RWATableSelect<ControlInputs extends FieldValues>(
@@ -20,10 +29,14 @@ export function RWATableSelect<ControlInputs extends FieldValues>(
         options,
         name,
         control,
-        required = false,
+        required,
+        errorMessage,
+        errorMessageClassName,
         disabled = false,
         ...restProps
     } = props;
+
+    const invalid = props['aria-invalid'] === 'true';
 
     return (
         <Controller
@@ -34,19 +47,36 @@ export function RWATableSelect<ControlInputs extends FieldValues>(
                 disabled ? (
                     <>{options.find(option => option.value === value)?.label}</>
                 ) : (
-                    <Combobox
-                        options={options}
-                        onBlur={onBlur}
-                        value={options.find(option => option.value === value)}
-                        isDisabled={disabled}
-                        onChange={option =>
-                            !!option &&
-                            typeof option === 'object' &&
-                            'value' in option &&
-                            onChange(option.value)
-                        }
-                        {...restProps}
-                    />
+                    <>
+                        <Combobox
+                            options={options}
+                            onBlur={onBlur}
+                            value={
+                                options.find(
+                                    option => option.value === value,
+                                ) ?? null
+                            }
+                            isDisabled={disabled}
+                            onChange={option =>
+                                !!option &&
+                                typeof option === 'object' &&
+                                'value' in option &&
+                                onChange(option.value)
+                            }
+                            {...restProps}
+                        />
+                        {invalid && !!errorMessage && (
+                            <p
+                                role="alert"
+                                className={twMerge(
+                                    'text-sm text-red-900',
+                                    errorMessageClassName,
+                                )}
+                            >
+                                {errorMessage}
+                            </p>
+                        )}
+                    </>
                 )
             }
         />

--- a/src/rwa/components/table/accounts/useAccountForm.tsx
+++ b/src/rwa/components/table/accounts/useAccountForm.tsx
@@ -20,6 +20,7 @@ export function useAccountForm(
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               label: item.label,
               reference: item.reference,
           }

--- a/src/rwa/components/table/assets/assets-table.stories.tsx
+++ b/src/rwa/components/table/assets/assets-table.stories.tsx
@@ -59,7 +59,7 @@ export const Empty: Story = {
                     },
                 });
             },
-            args.simulateBackgroundUpdates ? 3000 : 0,
+            args.simulateBackgroundUpdates ? 3000 : null,
         );
 
         const onSubmitEdit: AssetsTableProps['onSubmitEdit'] = useCallback(

--- a/src/rwa/components/table/assets/assets-table.stories.tsx
+++ b/src/rwa/components/table/assets/assets-table.stories.tsx
@@ -122,6 +122,15 @@ export const Empty: Story = {
     },
 };
 
+export const EmptyAllowedToCreateDocuments: Story = {
+    ...Empty,
+    args: {
+        ...Empty.args,
+        isAllowedToCreateDocuments: true,
+        isAllowedToEditDocuments: true,
+    },
+};
+
 export const WithDataReadOnly: Story = {
     ...Empty,
     args: {

--- a/src/rwa/components/table/assets/assets-table.stories.tsx
+++ b/src/rwa/components/table/assets/assets-table.stories.tsx
@@ -153,3 +153,24 @@ export const WithDataAllowedToCreateDocuments: Story = {
         isAllowedToEditDocuments: true,
     },
 };
+
+export const WithManyItems: Story = {
+    ...WithDataAllowedToCreateDocuments,
+    args: {
+        ...WithDataAllowedToCreateDocuments.args,
+        state: {
+            ...mockStateInitial,
+            portfolio: [
+                mockCashAsset,
+                ...mockFixedIncomes,
+                ...Array.from({ length: 100 }, (_, i) => ({
+                    ...mockFixedIncomes[0],
+                    id: `fixed-income-${i + 1}`,
+                })),
+            ],
+            fixedIncomeTypes: mockFixedIncomeTypes,
+            spvs: mockSPVs,
+            transactions: mockGroupTransactions,
+        },
+    },
+};

--- a/src/rwa/components/table/assets/assets-table.tsx
+++ b/src/rwa/components/table/assets/assets-table.tsx
@@ -38,6 +38,7 @@ const columns = [
         label: 'Purchase Price',
         allowSorting: true,
         isNumberColumn: true,
+        decimalScale: 6,
     },
     {
         key: 'purchaseProceeds' as const,

--- a/src/rwa/components/table/assets/assets-table.tsx
+++ b/src/rwa/components/table/assets/assets-table.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/rwa';
 import { Fragment, useMemo, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { sumTotalForProperty } from './utils';
 
 const columns = [
     { key: 'name' as const, label: 'Name', allowSorting: true },
@@ -83,6 +84,15 @@ export function AssetsTable(props: AssetsTableProps) {
 
     const cashAsset = getCashAsset(state);
 
+    const totalPurchasePrice = sumTotalForProperty(assets, 'purchasePrice');
+    const totalPurchaseProceeds = sumTotalForProperty(
+        assets,
+        'purchaseProceeds',
+    );
+    const totalSalesProceeds = sumTotalForProperty(assets, 'salesProceeds');
+    const totalTotalDiscount = sumTotalForProperty(assets, 'totalDiscount');
+    const totalRealizedSurplus = sumTotalForProperty(assets, 'realizedSurplus');
+
     const cashAssetFormattedAsTableItem = {
         id: 'special-first-row',
         name: 'Cash $USD',
@@ -119,9 +129,7 @@ export function AssetsTable(props: AssetsTableProps) {
                         {column.key === 'notional' && (
                             <RWATableCell
                                 key={column.key}
-                                className={
-                                    column.isNumberColumn ? 'text-right' : ''
-                                }
+                                className="text-right"
                             >
                                 {handleTableDatum(
                                     cashAssetFormattedAsTableItem[column.key],
@@ -131,6 +139,75 @@ export function AssetsTable(props: AssetsTableProps) {
                         {column.key !== 'name' && column.key !== 'notional' && (
                             <RWATableCell></RWATableCell>
                         )}
+                    </Fragment>
+                ))}
+            </tr>
+        </RWATableRow>
+    );
+
+    const specialLastRow: TableProps<
+        FixedIncome,
+        TableItem<FixedIncome>
+    >['specialFirstRow'] = c => (
+        <RWATableRow tdProps={{ colSpan: 100 }}>
+            <tr
+                className={twMerge(
+                    'sticky bottom-0 bg-white [&>td:not(:first-child)]:border-l [&>td]:border-gray-300',
+                )}
+            >
+                {c.map(column => (
+                    <Fragment key={column.key}>
+                        {column.key === 'name' && (
+                            <RWATableCell>Totals</RWATableCell>
+                        )}
+                        {column.key === 'purchasePrice' && (
+                            <RWATableCell
+                                key={column.key}
+                                className="text-right"
+                            >
+                                {handleTableDatum(totalPurchasePrice)}
+                            </RWATableCell>
+                        )}
+                        {column.key === 'purchaseProceeds' && (
+                            <RWATableCell
+                                key={column.key}
+                                className="text-right"
+                            >
+                                {handleTableDatum(totalPurchaseProceeds)}
+                            </RWATableCell>
+                        )}
+                        {column.key === 'salesProceeds' && (
+                            <RWATableCell
+                                key={column.key}
+                                className="text-right"
+                            >
+                                {handleTableDatum(totalSalesProceeds)}
+                            </RWATableCell>
+                        )}
+                        {column.key === 'totalDiscount' && (
+                            <RWATableCell
+                                key={column.key}
+                                className="text-right"
+                            >
+                                {handleTableDatum(totalTotalDiscount)}
+                            </RWATableCell>
+                        )}
+                        {column.key === 'realizedSurplus' && (
+                            <RWATableCell
+                                key={column.key}
+                                className="text-right"
+                            >
+                                {handleTableDatum(totalRealizedSurplus)}
+                            </RWATableCell>
+                        )}
+                        {column.key !== 'name' &&
+                            column.key !== 'purchasePrice' &&
+                            column.key !== 'purchaseProceeds' &&
+                            column.key !== 'salesProceeds' &&
+                            column.key !== 'totalDiscount' &&
+                            column.key !== 'realizedSurplus' && (
+                                <RWATableCell></RWATableCell>
+                            )}
                     </Fragment>
                 ))}
             </tr>
@@ -149,6 +226,7 @@ export function AssetsTable(props: AssetsTableProps) {
                 setSelectedTableItem={setSelectedTableItem}
                 setOperation={setOperation}
                 specialFirstRow={specialFirstRow}
+                specialLastRow={specialLastRow}
             />
             {showForm && (
                 <div className="mt-4 rounded-md bg-white">

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -40,6 +40,7 @@ export function useAssetForm(
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               fixedIncomeTypeId: item.fixedIncomeTypeId,
               spvId: item.spvId,
               name: item.name,

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -202,6 +202,11 @@ export function useAssetForm(
                                 setShowCreateFixedIncomeTypeModal(true),
                             label: 'Create Fixed Income Type',
                         }}
+                        required="Asset type is required"
+                        aria-invalid={
+                            errors.fixedIncomeTypeId ? 'true' : 'false'
+                        }
+                        errorMessage={errors.fixedIncomeTypeId?.message}
                     />
                 ),
             },
@@ -221,6 +226,9 @@ export function useAssetForm(
                             onClick: () => setShowCreateSpvModal(true),
                             label: 'Create SPV',
                         }}
+                        required="SPV is required"
+                        aria-invalid={errors.spvId ? 'true' : 'false'}
+                        errorMessage={errors.spvId?.message}
                     />
                 ),
             },
@@ -232,6 +240,7 @@ export function useAssetForm(
             errors.CUSIP,
             errors.ISIN,
             errors.name,
+            errors.fixedIncomeTypeId,
             fixedIncomeTypes,
             item?.CUSIP,
             item?.ISIN,

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -111,6 +111,7 @@ export function useAssetForm(
                         aria-invalid={errors.name ? 'true' : 'false'}
                         errorMessage={errors.name?.message}
                         placeholder="E.g. My Asset"
+                        inputClassName="text-left"
                     />
                 ),
             },

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -78,7 +78,7 @@ export function useAssetForm(
                       {
                           label: 'Purchase Price',
                           Input: () => (
-                              <>{handleTableDatum(item?.purchasePrice)}</>
+                              <>{handleTableDatum(item?.purchasePrice, 6)}</>
                           ),
                       },
                       {
@@ -235,17 +235,18 @@ export function useAssetForm(
             ...derivedInputsToDisplay,
         ],
         [
-            control,
             derivedInputsToDisplay,
+            register,
+            operation,
+            errors.name,
             errors.CUSIP,
             errors.ISIN,
-            errors.name,
             errors.fixedIncomeTypeId,
-            fixedIncomeTypes,
+            errors.spvId,
             item?.CUSIP,
             item?.ISIN,
-            operation,
-            register,
+            control,
+            fixedIncomeTypes,
             spvs,
         ],
     );

--- a/src/rwa/components/table/assets/utils.ts
+++ b/src/rwa/components/table/assets/utils.ts
@@ -1,0 +1,10 @@
+type NumericKeys<T> = {
+    [K in keyof T]: T[K] extends number ? K : never;
+}[keyof T];
+
+export function sumTotalForProperty<T extends Record<string, any>>(
+    items: T[],
+    property: NumericKeys<T>,
+): number {
+    return items.reduce((acc, item) => acc + item[property], 0);
+}

--- a/src/rwa/components/table/base/formatted-number.tsx
+++ b/src/rwa/components/table/base/formatted-number.tsx
@@ -14,7 +14,7 @@ export function FormattedNumber(props: Props) {
         currency,
         decimalScale = 2,
         thousandSeparator = ',',
-        fixedDecimalScale = true,
+        fixedDecimalScale = false,
     } = props;
 
     const prefix = currency === 'USD' ? '$' : undefined;

--- a/src/rwa/components/table/base/item-details.tsx
+++ b/src/rwa/components/table/base/item-details.tsx
@@ -139,7 +139,9 @@ export function ItemDetails<
         >
             <div className="flex justify-between rounded-t-md border-b border-gray-300 bg-gray-100 p-3 font-semibold text-gray-800">
                 <div className="flex items-center">
-                    {itemName} #{tableItem?.itemNumber ?? 1}
+                    {tableItem?.itemNumber
+                        ? `${itemName} #${tableItem.itemNumber}`
+                        : `New ${itemName}`}
                 </div>
                 <div className="flex gap-x-2">
                     {showCancelButton && cancelButton}

--- a/src/rwa/components/table/base/table-base.tsx
+++ b/src/rwa/components/table/base/table-base.tsx
@@ -33,6 +33,7 @@ export const TableBase = fixedForwardRef(function TableBase<
         renderRow,
         onClickSort,
         specialFirstRow,
+        specialLastRow,
         maxHeight,
         tableRef,
         ...containerProps
@@ -113,6 +114,7 @@ export const TableBase = fixedForwardRef(function TableBase<
                         {tableData?.map((item, index) =>
                             renderRow(item, columns, index),
                         )}
+                        {specialLastRow?.(columns)}
                     </tbody>
                 </table>
             </div>

--- a/src/rwa/components/table/base/table.tsx
+++ b/src/rwa/components/table/base/table.tsx
@@ -126,7 +126,7 @@ export function Table<
                                 )}
                             {column.key === 'moreDetails' && (
                                 <MoreDetailsCell
-                                    isSelected
+                                    isSelected={isSelected}
                                     onClick={() => {
                                         if (isSelected) {
                                             setOperation(null);

--- a/src/rwa/components/table/base/table.tsx
+++ b/src/rwa/components/table/base/table.tsx
@@ -120,6 +120,7 @@ export function Table<
                                         ) ??
                                             handleTableDatum(
                                                 tableItem[column.key],
+                                                column.decimalScale,
                                             )}
                                     </RWATableCell>
                                 )}

--- a/src/rwa/components/table/base/table.tsx
+++ b/src/rwa/components/table/base/table.tsx
@@ -54,6 +54,7 @@ export function Table<
         setSelectedTableItem,
         setOperation,
         specialFirstRow,
+        specialLastRow,
     } = props;
 
     const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -156,6 +157,7 @@ export function Table<
                 maxHeight={maxHeight}
                 renderRow={renderRow}
                 specialFirstRow={specialFirstRow}
+                specialLastRow={specialLastRow}
             />
             {isAllowedToCreateDocuments && !operation && (
                 <>

--- a/src/rwa/components/table/fixed-income-types/useFixedIncomeTypeForm.tsx
+++ b/src/rwa/components/table/fixed-income-types/useFixedIncomeTypeForm.tsx
@@ -19,6 +19,7 @@ export function useFixedIncomeTypeForm(
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               name: item.name,
           }
         : createDefaultValues;

--- a/src/rwa/components/table/service-provider-fee-types/useServiceProviderFeeTypeForm.tsx
+++ b/src/rwa/components/table/service-provider-fee-types/useServiceProviderFeeTypeForm.tsx
@@ -111,6 +111,9 @@ export function useServiceProviderFeeTypeForm(
                             onClick: () => setShowCreateAccountModal(true),
                             label: 'Create Account',
                         }}
+                        required="Account is required"
+                        aria-invalid={errors.accountId ? 'true' : 'false'}
+                        errorMessage={errors.accountId?.message}
                     />
                 ),
             },

--- a/src/rwa/components/table/service-provider-fee-types/useServiceProviderFeeTypeForm.tsx
+++ b/src/rwa/components/table/service-provider-fee-types/useServiceProviderFeeTypeForm.tsx
@@ -36,6 +36,7 @@ export function useServiceProviderFeeTypeForm(
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               name: item.name,
               feeType: item.feeType,
               accountId: item.accountId,

--- a/src/rwa/components/table/spvs/useSpvForm.tsx
+++ b/src/rwa/components/table/spvs/useSpvForm.tsx
@@ -12,6 +12,7 @@ export function useSpvForm(props: FormHookProps<SPV, SPVFormInputs>) {
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               name: item.name,
           }
         : createDefaultValues;

--- a/src/rwa/components/table/transactions/fee-transactions-table.tsx
+++ b/src/rwa/components/table/transactions/fee-transactions-table.tsx
@@ -71,7 +71,7 @@ export function FeeTransactionsTable(props: Props) {
                                         <td className="w-52"></td>
                                         <td className="w-96">
                                             <RWATableSelect
-                                                required
+                                                required="Service provider is required"
                                                 control={props.control}
                                                 name={`fees.${index}.serviceProviderFeeTypeId`}
                                                 disabled={props.isViewOnly}
@@ -85,6 +85,12 @@ export function FeeTransactionsTable(props: Props) {
                                                         ),
                                                     label: 'Add Service Provider',
                                                 }}
+                                                aria-invalid={
+                                                    props.errors.fees?.[index]
+                                                        ?.serviceProviderFeeTypeId
+                                                        ? 'true'
+                                                        : 'false'
+                                                }
                                             />
                                         </td>
                                         <td className="w-52">
@@ -98,8 +104,7 @@ export function FeeTransactionsTable(props: Props) {
                                                 currency="USD"
                                                 aria-invalid={
                                                     props.errors.fees?.[index]
-                                                        ?.amount?.type ===
-                                                    'required'
+                                                        ?.amount
                                                         ? 'true'
                                                         : 'false'
                                                 }

--- a/src/rwa/components/table/transactions/group-transactions-table.stories.tsx
+++ b/src/rwa/components/table/transactions/group-transactions-table.stories.tsx
@@ -117,6 +117,15 @@ export const Empty: Story = {
     },
 };
 
+export const EmptyIsAllowedToCreateDocuments: Story = {
+    ...Empty,
+    args: {
+        ...Empty.args,
+        isAllowedToCreateDocuments: true,
+        isAllowedToEditDocuments: true,
+    },
+};
+
 export const WithDataReadyOnly: Story = {
     ...Empty,
     args: {

--- a/src/rwa/components/table/transactions/group-transactions-table.tsx
+++ b/src/rwa/components/table/transactions/group-transactions-table.tsx
@@ -50,6 +50,12 @@ const columns = [
         isNumberColumn: true,
     },
     {
+        key: 'totalFees' as const,
+        label: 'Total Fees ($)',
+        allowSorting: true,
+        isNumberColumn: true,
+    },
+    {
         key: 'cashBalanceChange' as const,
         label: 'Cash Balance Change ($)',
         allowSorting: true,
@@ -88,6 +94,8 @@ export function makeGroupTransactionsTableItems(
             transaction.cashTransaction?.amount,
             cashTransactionSign,
         );
+        const totalFees =
+            transaction.fees?.reduce((acc, fee) => acc + fee.amount, 0) ?? 0;
         const cashBalanceChange = transaction.cashBalanceChange;
 
         return {
@@ -99,6 +107,7 @@ export function makeGroupTransactionsTableItems(
             asset,
             quantity,
             cashAmount,
+            totalFees,
             cashBalanceChange,
         };
     });

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -161,11 +161,13 @@ export function useGroupTransactionForm(
             label: 'Transaction Type',
             Input: () => (
                 <RWATableSelect
-                    required
                     control={control}
                     name="type"
                     disabled={operation === 'view'}
                     options={transactionTypeOptions}
+                    required="Transaction type is required"
+                    aria-invalid={errors.type ? 'true' : 'false'}
+                    errorMessage={errors.type?.message}
                 />
             ),
         },
@@ -187,7 +189,6 @@ export function useGroupTransactionForm(
                   Input: () => (
                       <RWATableSelect
                           control={control}
-                          required
                           name="fixedIncomeId"
                           disabled={operation === 'view'}
                           options={fixedIncomeOptions}
@@ -195,6 +196,9 @@ export function useGroupTransactionForm(
                               onClick: () => setShowCreateAssetModal(true),
                               label: 'Create Asset',
                           }}
+                          required="Asset name is required"
+                          aria-invalid={errors.type ? 'true' : 'false'}
+                          errorMessage={errors.type?.message}
                       />
                   ),
               }

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -36,7 +36,7 @@ function UnitPrice(props: {
         <div className={twMerge('mt-1 w-fit', !props.isViewOnly && 'ml-auto')}>
             <span className="text-gray-600">Unit Price</span>{' '}
             <span className="text-gray-900">
-                <FormattedNumber value={unitPrice} />
+                <FormattedNumber value={unitPrice} decimalScale={6} />
             </span>
         </div>
     );

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -89,6 +89,7 @@ export function useGroupTransactionForm(
 
     const editDefaultValues = item
         ? {
+              id: item.id,
               type: item.type,
               entryTime: convertToDateTimeLocalFormat(item.entryTime),
               cashAmount: item.cashTransaction?.amount ?? null,
@@ -118,6 +119,7 @@ export function useGroupTransactionForm(
 
     function customSubmitHandler(data: GroupTransactionFormInputs) {
         if (!operation || operation === 'view') return;
+        const id = data.id;
         const type = data.type;
         const entryTime = data.entryTime;
         const cashAmount = data.cashAmount;
@@ -136,6 +138,7 @@ export function useGroupTransactionForm(
         const onSubmitForm = formActions[operation];
 
         onSubmitForm?.({
+            id,
             type,
             entryTime,
             cashAmount,

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -6,6 +6,7 @@ import {
     GroupTransactionsTableItem,
     RWANumberInput,
     RWATableSelect,
+    RWATableTextInput,
     allGroupTransactionTypes,
     assetGroupTransactions,
     calculateUnitPrice,
@@ -83,6 +84,7 @@ export function useGroupTransactionForm(
         fixedIncomeAmount: null,
         serviceProviderFeeTypeId: serviceProviderFeeTypes[0]?.id ?? null,
         fees: null,
+        txRef: null,
     };
 
     const editDefaultValues = item
@@ -93,7 +95,8 @@ export function useGroupTransactionForm(
               fixedIncomeId: fixedIncomes[0]?.id ?? null,
               fixedIncomeAmount: item.fixedIncomeTransaction?.amount ?? null,
               serviceProviderFeeTypeId: item.serviceProviderFeeTypeId ?? null,
-              fees: item.fees,
+              fees: item.fees ?? null,
+              txRef: item.txRef ?? null,
           }
         : createDefaultValues;
 
@@ -123,6 +126,7 @@ export function useGroupTransactionForm(
         const fixedIncomeAmount = isAssetTransaction
             ? data.fixedIncomeAmount
             : null;
+        const txRef = data.txRef ?? null;
         const fees = canHaveTransactionFees ? data.fees : null;
         const formActions = {
             create: onSubmitCreate,
@@ -139,6 +143,7 @@ export function useGroupTransactionForm(
             fixedIncomeAmount,
             serviceProviderFeeTypeId,
             fees,
+            txRef,
         });
     }
 
@@ -271,6 +276,19 @@ export function useGroupTransactionForm(
                         />
                     )}
                 </>
+            ),
+        },
+        {
+            label: 'Transaction reference',
+            Input: () => (
+                <RWATableTextInput
+                    {...register('txRef', {
+                        disabled: operation === 'view',
+                    })}
+                    aria-invalid={errors.txRef ? 'true' : 'false'}
+                    errorMessage={errors.txRef?.message}
+                    placeholder="E.g. 0x123..."
+                />
             ),
         },
     ].filter(Boolean);

--- a/src/rwa/components/table/types/form.ts
+++ b/src/rwa/components/table/types/form.ts
@@ -66,6 +66,7 @@ export type GroupTransactionFormInputs = {
     cashAmount?: number | null;
     fixedIncomeAmount?: number | null;
     serviceProviderFeeTypeId?: string | null;
+    txRef?: string | null;
 };
 
 export type AccountFormInputs = {

--- a/src/rwa/components/table/types/table.ts
+++ b/src/rwa/components/table/types/table.ts
@@ -34,6 +34,7 @@ export interface TableColumn<
     allowSorting?: boolean;
     isSpecialColumn?: boolean; // Used to identify index or more details columns
     isNumberColumn?: boolean; // Used to right-align numbers
+    decimalScale?: number; // Used to format numbers
 }
 
 export type TableBaseProps<

--- a/src/rwa/components/table/types/table.ts
+++ b/src/rwa/components/table/types/table.ts
@@ -92,6 +92,7 @@ export type GroupTransactionsTableItem = GroupTransaction & {
     asset: string | undefined;
     quantity: number | undefined;
     cashAmount: number | undefined;
+    totalFees: number;
     cashBalanceChange: number;
 };
 

--- a/src/rwa/components/table/types/table.ts
+++ b/src/rwa/components/table/types/table.ts
@@ -56,6 +56,7 @@ export type TableBaseProps<
     specialFirstRow?: (
         columns: TableColumn<TItem, TTableData>[],
     ) => JSX.Element;
+    specialLastRow?: (columns: TableColumn<TItem, TTableData>[]) => JSX.Element;
 };
 
 export type TableProps<
@@ -74,6 +75,7 @@ export type TableProps<
     specialFirstRow?: (
         columns: TableColumn<TItem, TTableData>[],
     ) => JSX.Element;
+    specialLastRow?: (columns: TableColumn<TItem, TTableData>[]) => JSX.Element;
 };
 
 export type TableWrapperProps<TFormInputs extends FieldValues> = {

--- a/src/rwa/components/table/utils.tsx
+++ b/src/rwa/components/table/utils.tsx
@@ -27,10 +27,11 @@ export function handleDateInTable(maybeDate: string | Date) {
     return maybeDate;
 }
 
-export function handleTableDatum(datum: ItemData) {
+export function handleTableDatum(datum: ItemData, decimalScale = 2) {
     if (datum === null || datum === undefined) return '--';
 
-    if (typeof datum === 'number') return <FormattedNumber value={datum} />;
+    if (typeof datum === 'number')
+        return <FormattedNumber value={datum} decimalScale={decimalScale} />;
 
     return handleDateInTable(datum);
 }

--- a/src/rwa/mocks/assets.ts
+++ b/src/rwa/mocks/assets.ts
@@ -24,7 +24,7 @@ export const mockFixedIncomes: Asset[] = [
         maturity: '2023-06-01T00:00:00.000Z',
         purchaseDate: '2021-03-28',
         notional: 43247.76,
-        purchasePrice: 97.24,
+        purchasePrice: 97.24456777,
         purchaseProceeds: 42054.12,
         totalDiscount: 1193.64,
         ISIN: undefined,

--- a/src/rwa/mocks/transactions.ts
+++ b/src/rwa/mocks/transactions.ts
@@ -16,21 +16,21 @@ export const mockFixedIncomeTransaction = {
     assetId: mockFixedIncomes[0].id,
     accountId: mockAccounts[1].id,
     amount: 1000,
-    entryTime: '2021-10-01',
+    entryTime: '2023-06-01T00:00:00.000Z',
 };
 
 export const mockCashTransaction = {
     id: 'cash-transaction-1',
     assetId: 'cash-asset-1',
     amount: 1000,
-    entryTime: '2021-10-01',
+    entryTime: '2023-06-01T00:00:00.000Z',
     counterPartyAccountId: mockPrincipalLenderAccountId,
 };
 
 export const mockGroupTransaction = {
     id: 'group-transaction-0',
     type: allGroupTransactionTypes[0],
-    entryTime: '2021-10-01 00:00:00',
+    entryTime: '2023-06-01T00:00:00.000Z',
     fees: [
         {
             id: 'fee-transaction-1',

--- a/src/rwa/types/index.ts
+++ b/src/rwa/types/index.ts
@@ -69,12 +69,11 @@ export type GroupTransaction = {
     type: GroupTransactionType;
     cashBalanceChange: number;
     entryTime: string;
-    serviceProviderFeeTypeId: string | null;
+    serviceProviderFeeTypeId?: string | null;
+    txRef?: string | null;
     fees?: TransactionFee[] | null;
     fixedIncomeTransaction?: BaseTransaction | null;
     cashTransaction?: BaseTransaction | null;
-    feeTransactions?: BaseTransaction[] | null;
-    interestTransaction?: BaseTransaction | null;
 };
 
 export type TransactionFee = {
@@ -90,7 +89,6 @@ export type BaseTransaction = {
     entryTime: string;
     tradeTime?: string | null;
     settlementTime?: string | null;
-    txRef?: string | null;
     accountId?: string | null;
     counterPartyAccountId?: string | null;
 };

--- a/src/rwa/utils/index.ts
+++ b/src/rwa/utils/index.ts
@@ -17,7 +17,7 @@ export function convertToDateTimeLocalFormat(date: Date | string = new Date()) {
 }
 
 export function formatDateForDisplay(date: Date | string) {
-    return format(date, 'yyyy-MM-dd HH:mm');
+    return format(date, 'yyyy/MM/dd, HH:mm:ss');
 }
 
 export function isAssetGroupTransactionType(


### PR DESCRIPTION
Fixes several minor QA updates as described [here](https://www.notion.so/makerdao-ses/RWA-QA-Scenarios-b430499a4a5e4890abc6afa8c2090509).

- Make ‘Unit Price’  / Purchase Price optional to 6 d.p. (show up to 6dp)
- Asset name not left aligned on the portfolio asset dropdown view
- Input and Display date time is in different formates on the TX page. Have YYYY/MM/DD for both
- Should be able to add a txn ref to each tx (optional)
- Totals on the portfolio page
- Add a type’ column to the tx tab (and a filter: should be multi-select)