### PR TITLE
feat: qa updates 7

### DIFF
--- a/src/rwa/components/table/base/table-base.tsx
+++ b/src/rwa/components/table/base/table-base.tsx
@@ -1,4 +1,4 @@
-import { Icon, fixedForwardRef, mergeClassNameProps } from '@/powerhouse';
+import { Icon, fixedForwardRef } from '@/powerhouse';
 import { Item, SortDirection, TableBaseProps, TableItem } from '@/rwa';
 import { Order } from 'natural-orderby';
 import React, { useState } from 'react';
@@ -36,6 +36,7 @@ export const TableBase = fixedForwardRef(function TableBase<
         specialLastRow,
         maxHeight,
         headerRef,
+        hasSelectedItem,
         ...containerProps
     } = props;
 
@@ -47,9 +48,11 @@ export const TableBase = fixedForwardRef(function TableBase<
     return (
         <>
             <div
-                {...mergeClassNameProps(
-                    containerProps,
-                    'relative overflow-scroll rounded-lg border border-gray-300 bg-white',
+                {...containerProps}
+                className={twMerge(
+                    'relative rounded-lg border border-gray-300 bg-white',
+                    hasSelectedItem ? 'overflow-hidden' : 'overflow-scroll',
+                    containerProps.className,
                 )}
                 ref={ref}
                 style={{ maxHeight }}

--- a/src/rwa/components/table/base/table.tsx
+++ b/src/rwa/components/table/base/table.tsx
@@ -149,6 +149,7 @@ export function Table<
                 tableData={sortedItems}
                 columns={columnsToShow}
                 maxHeight={maxHeight}
+                hasSelectedItem={!!selectedTableItem}
                 renderRow={renderRow}
                 specialFirstRow={specialFirstRow}
                 specialLastRow={specialLastRow}

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -259,7 +259,7 @@ export function useGroupTransactionForm(
               }
             : undefined,
         {
-            label: 'Asset Proceeds',
+            label: isAssetTransaction ? 'Asset Proceeds' : 'Cash Amount',
             Input: () => (
                 <>
                     <RWANumberInput

--- a/src/rwa/components/table/types/table.ts
+++ b/src/rwa/components/table/types/table.ts
@@ -53,6 +53,7 @@ export type TableBaseProps<
     footer?: ReactNode;
     headerRef: RefObject<HTMLTableSectionElement>;
     maxHeight?: string;
+    hasSelectedItem?: boolean;
     specialFirstRow?: (
         columns: TableColumn<TItem, TTableData>[],
     ) => JSX.Element;


### PR DESCRIPTION
- update `asset proceeds` input label to be `cash amount` for transactions other than asset transactions
- lock table scroll when showing item details 