### PR TITLE
feat: qa updates 8

### DIFF
--- a/src/rwa/components/inputs/text-input.tsx
+++ b/src/rwa/components/inputs/text-input.tsx
@@ -15,6 +15,7 @@ export const _RWATableTextInput = forwardRef(function RWATableTextInput(
 ) {
     const invalid = props['aria-invalid'] === 'true';
     const {
+        name,
         errorMessage,
         labelClassName,
         inputClassName,

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -32,7 +32,7 @@ export function useAssetForm(
         fixedIncomeTypeId: fixedIncomeTypes[0]?.id ?? null,
         spvId: spvs[0]?.id ?? null,
         name: null,
-        maturity: convertToDateTimeLocalFormat(new Date()),
+        maturity: null,
         ISIN: null,
         CUSIP: null,
         coupon: null,
@@ -44,7 +44,9 @@ export function useAssetForm(
               fixedIncomeTypeId: item.fixedIncomeTypeId,
               spvId: item.spvId,
               name: item.name,
-              maturity: convertToDateTimeLocalFormat(item.maturity),
+              maturity: item.maturity
+                  ? convertToDateTimeLocalFormat(item.maturity)
+                  : null,
               ISIN: item.ISIN,
               CUSIP: item.CUSIP,
               coupon: item.coupon,
@@ -179,8 +181,11 @@ export function useAssetForm(
                 Input: () => (
                     <DateTimeLocalInput
                         {...register('maturity', {
-                            required: true,
                             disabled: operation === 'view',
+                            setValueAs: value => {
+                                if (value === '') return null;
+                                return value as string;
+                            },
                         })}
                         name="maturity"
                     />

--- a/src/rwa/components/table/transactions/group-transactions-table.tsx
+++ b/src/rwa/components/table/transactions/group-transactions-table.tsx
@@ -1,6 +1,7 @@
 import { Combobox } from '@/connect';
 import {
     AssetFormInputs,
+    FEES_INCOME,
     FixedIncome,
     GroupTransaction,
     GroupTransactionDetails,
@@ -13,6 +14,7 @@ import {
     allGroupTransactionTypes,
     assetTransactionSignByTransactionType,
     cashTransactionSignByTransactionType,
+    feesTransactions,
     groupTransactionTypeLabels,
     isAssetGroupTransactionType,
     isFixedIncomeAsset,
@@ -95,8 +97,12 @@ export function makeGroupTransactionsTableItems(
             transaction.cashTransaction?.amount,
             cashTransactionSign,
         );
-        const totalFees =
-            transaction.fees?.reduce((acc, fee) => acc + fee.amount, 0) ?? 0;
+        const totalFees = feesTransactions.includes(transaction.type)
+            ? maybeAddSignToAmount(
+                  transaction.cashTransaction?.amount,
+                  transaction.type === FEES_INCOME ? -1 : 1,
+              ) ?? 0
+            : transaction.fees?.reduce((acc, fee) => acc + fee.amount, 0) ?? 0;
         const cashBalanceChange = transaction.cashBalanceChange;
 
         return {

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -17,6 +17,7 @@ import {
     makeFixedIncomeOptionLabel,
 } from '@/rwa';
 
+import { getIsTransaction } from '@/services/viem';
 import {
     ComponentPropsWithRef,
     ForwardedRef,
@@ -44,6 +45,7 @@ const TransactionReference = forwardRef(function TransactionReference(
     const maybeShortedValue = shouldShortenValue
         ? `${value.slice(0, maxLength)}...`
         : value;
+    const isTransaction = getIsTransaction(value);
 
     if (disabled)
         return (
@@ -52,7 +54,19 @@ const TransactionReference = forwardRef(function TransactionReference(
                     {maybeShortedValue}
                 </a>
                 {shouldShortenValue && (
-                    <Tooltip anchorSelect={`#${tooltipId}`}>{value}</Tooltip>
+                    <Tooltip anchorSelect={`#${tooltipId}`}>
+                        <p>{value}</p>
+                        {isTransaction && (
+                            <p className="mt-2 text-center">
+                                <a
+                                    className="text-blue-900 underline"
+                                    href={`https://etherscan.io/tx/${value}`}
+                                >
+                                    View on Etherscan
+                                </a>
+                            </p>
+                        )}
+                    </Tooltip>
                 )}
             </span>
         );

--- a/src/rwa/components/table/types/form.ts
+++ b/src/rwa/components/table/types/form.ts
@@ -37,7 +37,7 @@ export type AssetFormInputs = {
     id?: string;
     fixedIncomeTypeId?: string | null;
     spvId?: string | null;
-    maturity?: string;
+    maturity?: string | null;
     name?: string | null;
     ISIN?: string | null;
     CUSIP?: string | null;

--- a/src/rwa/mocks/transactions.ts
+++ b/src/rwa/mocks/transactions.ts
@@ -31,6 +31,7 @@ export const mockGroupTransaction = {
     id: 'group-transaction-0',
     type: allGroupTransactionTypes[0],
     entryTime: '2023-06-01T00:00:00.000Z',
+    txRef: '0x48f208afD0Abeacd4e7C8839Ea19e3CcCF0433DE0x48f208afD0Abeacd4e7C8839Ea19e3CcCF0433DE',
     fees: [
         {
             id: 'fee-transaction-1',

--- a/src/rwa/mocks/transactions.ts
+++ b/src/rwa/mocks/transactions.ts
@@ -31,7 +31,7 @@ export const mockGroupTransaction = {
     id: 'group-transaction-0',
     type: allGroupTransactionTypes[0],
     entryTime: '2023-06-01T00:00:00.000Z',
-    txRef: '0x48f208afD0Abeacd4e7C8839Ea19e3CcCF0433DE0x48f208afD0Abeacd4e7C8839Ea19e3CcCF0433DE',
+    txRef: '0x99f19e36b83f59159b917fa67282f913f6c85ecdee5f49d427048d5ed9508b0b',
     fees: [
         {
             id: 'fee-transaction-1',

--- a/src/rwa/types/index.ts
+++ b/src/rwa/types/index.ts
@@ -22,7 +22,7 @@ export type FixedIncome = {
     name: string;
     fixedIncomeTypeId: string;
     spvId: string;
-    maturity: string;
+    maturity: string | null;
     ISIN?: string | null;
     CUSIP?: string | null;
     coupon?: number | null;

--- a/src/services/viem.ts
+++ b/src/services/viem.ts
@@ -61,3 +61,14 @@ export const getEnsInfo = async (
     }
     return result;
 };
+
+export function getIsTransaction(hash: string | null | undefined) {
+    if (!isHexString(hash)) return false;
+    return hash.length === 66;
+}
+
+export function isHexString(
+    value: string | null | undefined,
+): value is `0x${string}` {
+    return typeof value === 'string' && value.startsWith('0x');
+}


### PR DESCRIPTION
Make asset maturity field optional
Add fees txn type values to the total fees column 
Add etherscan link when tx ref “0x….” (check for length to make sure its not an EOA)
txRef doesnt fully show when an eth hash