### PR TITLE
feat: fix drag and drop accidental rename

### DIFF
--- a/src/connect/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/connect/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -3,7 +3,6 @@ import {
     ItemsContextProvider,
     SUCCESS,
     generateMockDriveData,
-    randomId,
     useGetItemByPath,
     useItemActions,
     useItemsContext,
@@ -82,7 +81,8 @@ export const Default: Story = {
             args.onSubmitInput(basepath, label);
 
             const newItem: BaseTreeItem = {
-                id: randomId(),
+                id: 'new-item-id',
+                parentFolder: basepath,
                 path: `${basepath}/${label}`,
                 label,
                 type: 'FOLDER',
@@ -102,7 +102,8 @@ export const Default: Story = {
             args.onAddNewItem(basePath, option);
 
             actions.newVirtualItem({
-                id: randomId(),
+                id: 'new-folder',
+                parentFolder: basePath,
                 path: `${basePath}/new-folder`,
                 label: option,
                 type: 'FOLDER',

--- a/src/connect/components/file-item/file-item.stories.tsx
+++ b/src/connect/components/file-item/file-item.stories.tsx
@@ -42,6 +42,7 @@ export const ReadMode: Story = {
         icon: 'profile',
         item: {
             id: '1',
+            parentFolder: null,
             label: 'Test Folder',
             availableOffline: false,
             path: '',

--- a/src/connect/components/file-item/file-item.test.tsx
+++ b/src/connect/components/file-item/file-item.test.tsx
@@ -4,6 +4,7 @@ import { FileItem } from './file-item';
 
 const item: TreeItem = {
     id: '1',
+    parentFolder: null,
     label: 'Test Folder',
     availableOffline: false,
     path: '',

--- a/src/connect/components/folder-item/folder-item.stories.tsx
+++ b/src/connect/components/folder-item/folder-item.stories.tsx
@@ -34,6 +34,7 @@ export const ReadMode: Story = {
         displaySyncIcon: true,
         item: {
             id: '1',
+            parentFolder: null,
             label: 'Test Folder',
             availableOffline: false,
             path: '',

--- a/src/connect/components/folder-item/folder-item.test.tsx
+++ b/src/connect/components/folder-item/folder-item.test.tsx
@@ -4,6 +4,7 @@ import { FolderItem } from './folder-item';
 
 const item: TreeItem = {
     id: '1',
+    parentFolder: null,
     label: 'Test Folder',
     availableOffline: false,
     path: '',

--- a/src/connect/components/tree-view-item/tree-view-item.stories.tsx
+++ b/src/connect/components/tree-view-item/tree-view-item.stories.tsx
@@ -32,6 +32,7 @@ export const TreeViewItem: Story = {
         item: {
             id: 'drive/folder1',
             path: 'drive/folder1',
+            parentFolder: null,
             label: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
             type: 'FOLDER',
             expanded: false,

--- a/src/connect/components/tree-view/tree-view.stories.tsx
+++ b/src/connect/components/tree-view/tree-view.stories.tsx
@@ -81,6 +81,7 @@ const TreeViewImpl = (args: ConnectTreeViewProps) => {
                 actions.setExpandedItem(item.id, true);
                 actions.newVirtualItem({
                     id: `${item.id}/new-folder`,
+                    parentFolder: item.id,
                     path: `${item.path}/new-folder`,
                     label: 'New Folder',
                     type: 'FOLDER',

--- a/src/connect/hooks/tree-view/mocks.ts
+++ b/src/connect/hooks/tree-view/mocks.ts
@@ -3,6 +3,7 @@ import { MISSING, TreeItem } from '@/connect';
 export const driveItem: TreeItem = {
     id: 'drive',
     path: 'drive',
+    parentFolder: null,
     label: 'Local Drive',
     type: 'LOCAL_DRIVE',
     expanded: false,
@@ -14,7 +15,8 @@ export const driveItem: TreeItem = {
 export const treeItems: Array<TreeItem> = [
     driveItem,
     {
-        id: 'drive/folder1',
+        id: 'folder1',
+        parentFolder: null,
         path: 'drive/folder1',
         label: 'Folder 1',
         type: 'FOLDER',
@@ -24,7 +26,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder1/folder1.1',
+        id: 'folder1.1',
+        parentFolder: 'folder1',
         path: 'drive/folder1/folder1.1',
         label: 'Folder 1.1',
         type: 'FOLDER',
@@ -34,7 +37,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder1/folder1.2',
+        id: 'folder1.2',
+        parentFolder: 'folder1',
         path: 'drive/folder1/folder1.2',
         label: 'Folder 1.2',
         type: 'FOLDER',
@@ -44,7 +48,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder1/folder1.2/folder1.2.1',
+        id: 'folder1.2.1',
+        parentFolder: 'folder1.2',
         path: 'drive/folder1/folder1.2/folder1.2.1',
         label: 'Folder 1.2.1',
         type: 'FOLDER',
@@ -54,7 +59,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder2',
+        id: 'folder2',
+        parentFolder: null,
         path: 'drive/folder2',
         label: 'Folder 2',
         type: 'FOLDER',
@@ -64,7 +70,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder2/folder2.1',
+        id: 'folder2.1',
+        parentFolder: 'folder2',
         path: 'drive/folder2/folder2.1',
         label: 'Folder 2.1',
         type: 'FOLDER',
@@ -74,7 +81,8 @@ export const treeItems: Array<TreeItem> = [
         isSelected: false,
     },
     {
-        id: 'drive/folder3',
+        id: 'folder3',
+        parentFolder: null,
         path: 'drive/folder3',
         label: 'Folder 3',
         type: 'FOLDER',

--- a/src/connect/hooks/tree-view/useGetItemById/useGetItemById.test.ts
+++ b/src/connect/hooks/tree-view/useGetItemById/useGetItemById.test.ts
@@ -15,12 +15,13 @@ describe('TreeView hooks', () => {
             const { result } = renderHook(() => useGetItemById());
             const getItemById = result.current;
 
-            const item = getItemById('drive/folder1/folder1.2');
+            const item = getItemById('folder1.2');
 
             expect(item).toEqual({
-                id: 'drive/folder1/folder1.2',
+                id: 'folder1.2',
                 path: 'drive/folder1/folder1.2',
                 label: 'Folder 1.2',
+                parentFolder: 'folder1',
                 type: 'FOLDER',
                 syncStatus: 'SYNCING',
                 expanded: false,

--- a/src/connect/hooks/tree-view/useItemActions/useItemActions.test.ts
+++ b/src/connect/hooks/tree-view/useItemActions/useItemActions.test.ts
@@ -8,6 +8,7 @@ import { useItemActions } from './useItemActions';
 const baseItem = {
     id: 'base-item',
     expanded: true,
+    parentFolder: null,
     path: 'drive-id/base-item',
     label: 'Base Item',
     type: FOLDER,

--- a/src/connect/hooks/tree-view/usePathContent/usePathContent.test.ts
+++ b/src/connect/hooks/tree-view/usePathContent/usePathContent.test.ts
@@ -25,13 +25,13 @@ describe('TreeView hooks', () => {
             );
 
             expect(driveNodes.result.current.length).toEqual(3);
-            expect(driveNodes.result.current[0].id).toEqual('drive/folder1');
-            expect(driveNodes.result.current[1].id).toEqual('drive/folder2');
-            expect(driveNodes.result.current[2].id).toEqual('drive/folder3');
+            expect(driveNodes.result.current[0].id).toEqual('folder1');
+            expect(driveNodes.result.current[1].id).toEqual('folder2');
+            expect(driveNodes.result.current[2].id).toEqual('folder3');
 
             expect(folderNodes.result.current.length).toEqual(1);
             expect(folderNodes.result.current[0].id).toEqual(
-                'drive/folder1/folder1.2/folder1.2.1',
+                'folder1.2.1',
             );
         });
 

--- a/src/connect/types/ui.ts
+++ b/src/connect/types/ui.ts
@@ -31,6 +31,7 @@ export type BaseTreeItem = {
     label: string;
     type: TreeItemType;
     availableOffline: boolean;
+    parentFolder: string | null;
     syncStatus?: SyncStatus;
     error?: Error;
     options?: ConnectDropdownMenuItem[];

--- a/src/connect/types/ui.ts
+++ b/src/connect/types/ui.ts
@@ -31,7 +31,7 @@ export type BaseTreeItem = {
     label: string;
     type: TreeItemType;
     availableOffline: boolean;
-    parentFolder: string | null;
+    parentFolder: string | null | undefined;
     syncStatus?: SyncStatus;
     error?: Error;
     options?: ConnectDropdownMenuItem[];

--- a/src/connect/utils/mocks/tree-item.ts
+++ b/src/connect/utils/mocks/tree-item.ts
@@ -11,25 +11,30 @@ export const randomId = function (length = 10) {
  * @param driveItem - The drive item to generate mock data for.
  * @returns An array of tree items representing the mock drive data.
  */
-export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
+export const generateMockDriveData = (
+    driveItem: Omit<TreeItem, 'id' | 'parentFolder'>,
+) => {
     const drive = driveItem.path;
 
     const treeItems: Array<TreeItem> = [
         {
             ...driveItem,
-            id: randomId(),
+            id: 'drive',
+            parentFolder: null,
             path: drive,
         },
         {
-            id: randomId(),
+            id: 'folder1',
             path: `${drive}/folder1`,
+            parentFolder: 'drive',
             label: 'Folder 1',
             type: 'FOLDER',
             availableOffline: false,
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder1.1',
+            parentFolder: 'folder1',
             path: `${drive}/folder1/folder1.1`,
             label: 'Folder 1.1',
             type: 'FOLDER',
@@ -37,7 +42,8 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder1.2',
+            parentFolder: 'folder1',
             path: `${drive}/folder1/folder1.2`,
             label: 'Folder 1.2',
             type: 'FOLDER',
@@ -45,7 +51,8 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder1.2.1',
+            parentFolder: 'folder1.2',
             path: `${drive}/folder1/folder1.2/folder1.2.1`,
             label: 'Folder 1.2.1',
             type: 'FOLDER',
@@ -53,7 +60,8 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder2',
+            parentFolder: 'drive',
             path: `${drive}/folder2`,
             label: 'Folder 2',
             type: 'FOLDER',
@@ -61,7 +69,8 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder2.1',
+            parentFolder: 'folder2',
             path: `${drive}/folder2/folder2.1`,
             label: 'Folder 2.1',
             type: 'FOLDER',
@@ -69,7 +78,8 @@ export const generateMockDriveData = (driveItem: Omit<TreeItem, 'id'>) => {
             syncStatus: 'SYNCING',
         },
         {
-            id: randomId(),
+            id: 'folder3',
+            parentFolder: 'drive',
             path: `${drive}/folder3`,
             label: 'Folder 3 Folder 3 Folder 3 Folder 3 Folder 3',
             type: 'FOLDER',


### PR DESCRIPTION
include node's `parentFolder` in tree item so that it can be used for things like avoiding a move operation when moving to the existing parent.