### PR TITLE
feat: add infinite scroll for revision history

### DIFF
--- a/src/connect/components/revision-history/mocks.ts
+++ b/src/connect/components/revision-history/mocks.ts
@@ -1,3 +1,4 @@
+import { addDays } from 'date-fns';
 import { Operation, SignatureArray } from './types';
 
 export const mockSignature: SignatureArray = [
@@ -66,6 +67,12 @@ export const mockOperations = [
         timestamp: '2024-06-15T14:39:12.936Z',
     },
     { ...mockOperation, timestamp: '2024-06-15T14:39:12.936Z' },
+    ...Array.from({ length: 100 }, (_, index) =>
+        Array.from({ length: 5 }, () => ({
+            ...mockOperation,
+            timestamp: addDays(`2024-06-15T14:39:12.936Z`, index).toISOString(),
+        })),
+    ).flat(),
 ].map((op, index) => ({
     ...op,
     index,

--- a/src/connect/components/revision-history/revision-history.stories.tsx
+++ b/src/connect/components/revision-history/revision-history.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { globalOperations, localOperations } from './mocks';
+import nsOperations from './ns-operations.json';
 import { RevisionHistory } from './revision-history';
+import { Operation } from './types';
 
 const meta = {
     title: 'Connect/Components/Revision History/Revision History',
@@ -11,11 +13,16 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const operations = nsOperations as unknown as {
+    global: Operation[];
+    local: Operation[];
+};
+
 export const Default: Story = {
     args: {
         documentTitle: ' MakerDAO/Monetalis RWA Report 050724',
         documentId: '6wYLICDhX5w1Hq7mIo6CRbXUV1I=',
-        globalOperations,
+        globalOperations: operations.global,
         localOperations,
         onClose: () => {},
     },

--- a/src/connect/components/revision-history/revision/revision.stories.tsx
+++ b/src/connect/components/revision-history/revision/revision.stories.tsx
@@ -26,7 +26,7 @@ export const Verified: Story = {
         },
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
         chainId: 1,
-        timestamp: 1719232415114,
+        timestamp: '1719232415114',
         signatures: [
             {
                 signerAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
@@ -63,7 +63,7 @@ export const PartiallyVerified: Story = {
         },
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
         chainId: 1,
-        timestamp: 1719232415114,
+        timestamp: '1719232415114',
         signatures: [
             {
                 signerAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
@@ -100,7 +100,7 @@ export const NotVerified: Story = {
         },
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
         chainId: 1,
-        timestamp: 1719232415114,
+        timestamp: '1719232415114',
         signatures: [
             {
                 signerAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',

--- a/src/connect/components/revision-history/timeline/revisions-on-date.stories.tsx
+++ b/src/connect/components/revision-history/timeline/revisions-on-date.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -65,7 +65,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -101,7 +101,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -123,10 +123,6 @@ export const Default: Story = {
                 errors: ['Data mismatch detected'],
             },
             {
-                operationIndex: 4,
-                skipCount: 1,
-            },
-            {
                 operationIndex: 6,
                 eventId: '123',
                 stateHash: 'wH041NamJQq3AHgk8tD/suXDDI=',
@@ -141,7 +137,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -177,7 +173,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -213,7 +209,7 @@ export const Default: Story = {
                 },
                 address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
                 chainId: 1,
-                timestamp: 1719232415114,
+                timestamp: '1719232415114',
                 signatures: [
                     {
                         signerAddress:
@@ -233,10 +229,6 @@ export const Default: Story = {
                     },
                 ],
                 errors: ['Data mismatch detected'],
-            },
-            {
-                operationIndex: 9,
-                skipCount: 3,
             },
         ],
     },

--- a/src/connect/components/revision-history/timeline/revisions-on-date.tsx
+++ b/src/connect/components/revision-history/timeline/revisions-on-date.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@/powerhouse';
 import { format } from 'date-fns';
+import { useMemo } from 'react';
 import { Revision } from '../revision';
 import { Skip } from '../skip';
 import { Revision as TRevision, Skip as TSkip } from '../types';
@@ -9,17 +10,27 @@ export type RevisionsOnDateProps = {
     revisionsAndSkips: (TRevision | TSkip)[];
 };
 
+function getRevisionsAndSkipsForDay(
+    timestamp: string,
+    revisionsAndSkips: (TRevision | TSkip)[],
+) {
+    const day = timestamp.split('T')[0];
+    return revisionsAndSkips.filter(
+        revisionOrSkip => revisionOrSkip.timestamp.split('T')[0] === day,
+    );
+}
+
 export function RevisionsOnDate(props: RevisionsOnDateProps) {
     const { date, revisionsAndSkips } = props;
+
+    const revisionsForDay = useMemo(
+        () => getRevisionsAndSkipsForDay(date, revisionsAndSkips),
+        [date, revisionsAndSkips],
+    );
+
+    if (!revisionsForDay.length) return null;
+
     const formattedDate = format(date, 'MMM dd, yyyy');
-
-    const content = revisionsAndSkips.map((revisionOrSkip, index) => {
-        if ('skipCount' in revisionOrSkip) {
-            return <Skip key={index} {...revisionOrSkip} />;
-        }
-
-        return <Revision key={index} {...revisionOrSkip} />;
-    });
 
     return (
         <section>
@@ -27,7 +38,13 @@ export function RevisionsOnDate(props: RevisionsOnDateProps) {
                 <Icon name="ring" size={16} /> Changes on {formattedDate}
             </h2>
             <div className="grid gap-2 border-l border-slate-100 px-4 py-2">
-                {content}
+                {revisionsForDay.map((revisionOrSkip, index) => {
+                    if ('skipCount' in revisionOrSkip) {
+                        return <Skip key={index} {...revisionOrSkip} />;
+                    }
+
+                    return <Revision key={index} {...revisionOrSkip} />;
+                })}
             </div>
         </section>
     );

--- a/src/connect/components/revision-history/timeline/timeline.tsx
+++ b/src/connect/components/revision-history/timeline/timeline.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Operation, Scope } from '../types';
-import { makeRevisionsByDate } from '../utils';
+import { getUniqueDatesInOrder, makeRevisionsAndSkips } from '../utils';
 import { RevisionsOnDate } from './revisions-on-date';
 
 export type TimelineProps = {
@@ -10,18 +11,49 @@ export type TimelineProps = {
 
 export function Timeline(props: TimelineProps) {
     const { localOperations, globalOperations, scope } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const [scrollAmount, setScrollAmount] = useState(0);
+    const [numRevisionsToShow, setNumRevisionsToShow] = useState(20);
     const operations = scope === 'local' ? localOperations : globalOperations;
-    const revisionsByDate = makeRevisionsByDate(operations);
-    const sortedDates = Object.keys(revisionsByDate).sort(
-        (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+    const dates = getUniqueDatesInOrder(operations);
+    const revisionsAndSkips = useMemo(
+        () => makeRevisionsAndSkips(operations),
+        [operations],
     );
+    const itemsToShow = revisionsAndSkips.slice(0, numRevisionsToShow);
+
+    useEffect(() => {
+        const ratio = Math.floor(scrollAmount / 46);
+        const newNumRevisions = 20 + ratio;
+        setNumRevisionsToShow(prev =>
+            newNumRevisions > prev ? newNumRevisions : prev,
+        );
+    }, [scrollAmount]);
+
+    const handleScroll = (e: WheelEvent) => {
+        setScrollAmount(prev => {
+            const n = prev + e.deltaY;
+            if (n < 0) {
+                return 0;
+            }
+            return n;
+        });
+    };
+
+    useEffect(() => {
+        window.addEventListener('wheel', handleScroll);
+        return () => {
+            window.removeEventListener('wheel', handleScroll);
+        };
+    }, []);
+
     return (
-        <div className="grid gap-2">
-            {sortedDates.map(date => (
+        <div ref={ref} className="grid gap-2">
+            {dates.map(date => (
                 <RevisionsOnDate
                     key={date}
                     date={date}
-                    revisionsAndSkips={revisionsByDate[date]}
+                    revisionsAndSkips={itemsToShow}
                 />
             ))}
         </div>

--- a/src/connect/components/revision-history/types.ts
+++ b/src/connect/components/revision-history/types.ts
@@ -23,6 +23,7 @@ export type Operation = {
 export type Skip = {
     operationIndex: number;
     skipCount: number;
+    timestamp: string;
 };
 
 //  [
@@ -49,7 +50,7 @@ export type Revision = {
     operationInput: Record<string, any>;
     address: `0x${string}` | undefined;
     chainId: number | undefined;
-    timestamp: number | string;
+    timestamp: string;
     signatures: Signature[] | undefined;
     errors: string[] | undefined;
 };


### PR DESCRIPTION
Using tanstack's list virtualization library for this proved to not work. Since the revision history is a list of lists, i.e. a list of dates with their revisions, the tanstack library is unable to fully optimize the revisions individually.

I have instead implemented a more traditional style infinite scroll logic, where more items are added to the list to show as the user scrolls.

At first I did this by listening to the 'scroll' event on the window. This worked perfectly on storybook, but something about the DOM hierarchy in connect causes the 'scroll' event to not fire. So I am listening to the 'wheel' event instead. I hope this doesn't have unintended consequences, but it seems to work quite nicely.