### PR TITLE
feat: use radix tooltip instead of react tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   "dependencies": {
     "@internationalized/date": "^3.5.1",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-virtual": "^3.8.1",
     "change-case": "^5.4.3",
@@ -128,7 +129,6 @@
     "react-number-format": "^5.3.4",
     "react-select": "^5.8.0",
     "react-toastify": "^10.0.4",
-    "react-tooltip": "^5.27.0",
     "viem": "^2.16.1",
     "wagmi": "^2.10.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.0.5
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.49.2
         version: 5.49.2(react@18.3.1)
@@ -44,9 +47,6 @@ importers:
       react-toastify:
         specifier: ^10.0.4
         version: 10.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-tooltip:
-        specifier: ^5.27.0
-        version: 5.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       viem:
         specifier: ^2.16.1
         version: 2.16.5(bufferutil@4.0.8)(typescript@5.5.2)(zod@3.23.8)
@@ -1468,6 +1468,12 @@ packages:
   '@floating-ui/dom@1.6.7':
     resolution: {integrity: sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==}
 
+  '@floating-ui/react-dom@2.1.1':
+    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.4':
     resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
 
@@ -1989,6 +1995,19 @@ packages:
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
+  '@radix-ui/react-arrow@1.1.0':
+    resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
@@ -2064,6 +2083,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-popper@1.2.0':
+    resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.1':
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
     peerDependencies:
@@ -2112,6 +2144,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tooltip@1.1.2':
+    resolution: {integrity: sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.0':
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
     peerDependencies:
@@ -2147,6 +2192,40 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-rect@1.1.0':
+    resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.1.0':
+    resolution: {integrity: sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.0':
+    resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
   '@react-aria/breadcrumbs@3.5.13':
     resolution: {integrity: sha512-G1Gqf/P6kVdfs94ovwP18fTWuIxadIQgHsXS08JEVcFVYMjb9YjqnEBaohUxD1tq2WldMbYw53ahQblT4NTG+g==}
@@ -4316,9 +4395,6 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
-
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -7923,12 +7999,6 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  react-tooltip@5.27.0:
-    resolution: {integrity: sha512-JXROcdfCEbCqkAkh8LyTSP3guQ0dG53iY2E2o4fw3D8clKzziMpE6QG6CclDaHELEKTzpMSeAOsdtg0ahoQosw==}
-    peerDependencies:
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
-
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -10956,6 +11026,12 @@ snapshots:
       '@floating-ui/core': 1.6.4
       '@floating-ui/utils': 0.2.4
 
+  '@floating-ui/react-dom@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.6.7
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/utils@0.2.4': {}
 
   '@formatjs/ecma402-abstract@2.0.0':
@@ -11657,6 +11733,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.0': {}
 
+  '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -11728,6 +11813,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-popper@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11764,6 +11867,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-tooltip@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -11789,6 +11912,31 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
+
+  '@radix-ui/react-use-rect@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/rect@1.1.0': {}
 
   '@react-aria/breadcrumbs@3.5.13(react@18.3.1)':
     dependencies:
@@ -15549,8 +15697,6 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.2.3
-
-  classnames@2.5.1: {}
 
   clean-stack@2.2.0: {}
 
@@ -19713,13 +19859,6 @@ snapshots:
   react-toastify@10.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  react-tooltip@5.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@floating-ui/dom': 1.6.7
-      classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/src/connect/components/index.ts
+++ b/src/connect/components/index.ts
@@ -5,6 +5,7 @@ export * from './disclosure';
 export * from './divider';
 export * from './drive-view';
 export * from './dropdown-menu';
+export * from './ens-avatar';
 export * from './file-item';
 export * from './folder-item';
 export * from './form';

--- a/src/connect/components/revision-history/revision-history.tsx
+++ b/src/connect/components/revision-history/revision-history.tsx
@@ -1,6 +1,7 @@
+import { TooltipProvider } from '@/connect';
 import { useState } from 'react';
 import { Header } from './header';
-import { Timeline } from './timeline/timeline';
+import { Timeline } from './timeline';
 import { Operation, Scope } from './types';
 
 type Props = {
@@ -26,23 +27,25 @@ export function RevisionHistory(props: Props) {
     }
 
     return (
-        <div className="h-[calc(100vh-86px)]">
-            <Header
-                title={documentTitle}
-                docId={documentId}
-                scope={scope}
-                onChangeScope={onChangeScope}
-                onClose={onClose}
-            />
-            <div className="mt-9 flex h-full justify-center rounded-md bg-slate-50 py-4">
-                <div className="grid grid-cols-[minmax(min-content,1018px)]">
-                    <Timeline
-                        scope={scope}
-                        globalOperations={globalOperations}
-                        localOperations={localOperations}
-                    />
+        <TooltipProvider>
+            <div className="h-[calc(100vh-86px)]">
+                <Header
+                    title={documentTitle}
+                    docId={documentId}
+                    scope={scope}
+                    onChangeScope={onChangeScope}
+                    onClose={onClose}
+                />
+                <div className="mt-9 flex h-full justify-center rounded-md bg-slate-50 p-4">
+                    <div className="grid grid-cols-[minmax(min-content,1018px)]">
+                        <Timeline
+                            scope={scope}
+                            globalOperations={globalOperations}
+                            localOperations={localOperations}
+                        />
+                    </div>
                 </div>
             </div>
-        </div>
+        </TooltipProvider>
     );
 }

--- a/src/connect/components/revision-history/revision/address.tsx
+++ b/src/connect/components/revision-history/revision/address.tsx
@@ -1,5 +1,8 @@
 import { formatEthAddress } from '@/connect/utils';
+import { Icon } from '@/powerhouse';
+import { useCopyToClipboard } from 'usehooks-ts';
 import { ENSAvatar } from '../../ens-avatar';
+import { Tooltip } from '../../tooltip';
 
 export type AddressProps = {
     address: `0x${string}` | undefined;
@@ -8,15 +11,40 @@ export type AddressProps = {
 
 export function Address(props: AddressProps) {
     const { address, chainId } = props;
+    const [, copy] = useCopyToClipboard();
 
     if (!address) return null;
 
     const shortenedAddress = formatEthAddress(address);
 
+    function handleCopy(text: string) {
+        return () => {
+            copy(text).catch(error => {
+                console.error('Failed to copy!', error);
+            });
+        };
+    }
+
+    const tooltipContent = (
+        <button
+            onClick={handleCopy(address)}
+            className="flex items-center gap-1"
+        >
+            {address}
+            <Icon
+                name="files-earmark"
+                className="inline-block text-gray-600"
+                size={16}
+            />
+        </button>
+    );
+
     return (
-        <span className="flex w-fit items-center gap-1 rounded-lg bg-gray-100 p-1 text-xs text-slate-100">
-            <ENSAvatar address={address} chainId={chainId} />
-            {shortenedAddress}
-        </span>
+        <Tooltip content={tooltipContent}>
+            <span className="flex w-fit cursor-pointer items-center gap-1 rounded-lg bg-gray-100 p-1 text-xs text-slate-100">
+                <ENSAvatar address={address} chainId={chainId} />
+                {shortenedAddress}
+            </span>
+        </Tooltip>
     );
 }

--- a/src/connect/components/revision-history/revision/address.tsx
+++ b/src/connect/components/revision-history/revision/address.tsx
@@ -1,8 +1,6 @@
-import { formatEthAddress } from '@/connect/utils';
+import { ENSAvatar, formatEthAddress, Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
 import { useCopyToClipboard } from 'usehooks-ts';
-import { ENSAvatar } from '../../ens-avatar';
-import { Tooltip } from '../../tooltip';
 
 export type AddressProps = {
     address: `0x${string}` | undefined;

--- a/src/connect/components/revision-history/revision/errors.tsx
+++ b/src/connect/components/revision-history/revision/errors.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
-import { useId } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export type ErrorsProps = {
@@ -9,7 +8,6 @@ export type ErrorsProps = {
 
 export function Errors(props: ErrorsProps) {
     const { errors } = props;
-    const tooltipId = useId().replace(/:/g, '');
 
     const hasErrors = !!errors?.length;
 
@@ -23,34 +21,28 @@ export function Errors(props: ErrorsProps) {
 
     const text = hasErrors ? `Error: ${errors[0]}` : 'No errors';
 
-    const fullErrorsText = errors?.map((message, index) => (
+    const content = (
+        <span
+            className={twMerge(
+                'flex w-fit items-center rounded-lg border border-gray-200 px-2 py-1 text-xs',
+                color,
+                hasErrors && 'cursor-pointer',
+            )}
+        >
+            {icon}
+            <span className={twMerge('inline-block max-w-36 truncate')}>
+                {text}
+            </span>
+        </span>
+    );
+
+    const tooltipContent = errors?.map((message, index) => (
         <p key={index} className="text-red-800">
             Error: {message}
         </p>
     ));
 
-    return (
-        <span
-            className={twMerge(
-                'flex w-fit items-center rounded-lg border border-gray-200 px-2 py-1 text-xs',
-                color,
-            )}
-        >
-            {icon}
-            <a
-                id={tooltipId}
-                className={twMerge(
-                    'inline-block max-w-36 truncate',
-                    hasErrors && 'cursor-pointer',
-                )}
-            >
-                {text}
-            </a>
-            {hasErrors && (
-                <Tooltip anchorSelect={`#${tooltipId}`}>
-                    {fullErrorsText}
-                </Tooltip>
-            )}
-        </span>
-    );
+    if (hasErrors) return <Tooltip content={tooltipContent}>{content}</Tooltip>;
+
+    return content;
 }

--- a/src/connect/components/revision-history/revision/operation.tsx
+++ b/src/connect/components/revision-history/revision/operation.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
-import { Tooltip } from '../../tooltip/tooltip';
 
 export type OperationProps = {
     operationType: string;

--- a/src/connect/components/revision-history/revision/operation.tsx
+++ b/src/connect/components/revision-history/revision/operation.tsx
@@ -1,6 +1,5 @@
-import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
-import { useId } from 'react';
+import { Tooltip } from '../../tooltip/tooltip';
 
 export type OperationProps = {
     operationType: string;
@@ -9,19 +8,19 @@ export type OperationProps = {
 
 export function Operation(props: OperationProps) {
     const { operationType, operationInput } = props;
-    const tooltipId = useId().replace(/:/g, '');
+
+    const tooltipContent = (
+        <code>
+            <pre>{JSON.stringify(operationInput, null, 2)}</pre>
+        </code>
+    );
 
     return (
-        <span className="flex items-center gap-2 text-xs">
-            {operationType}
-            <a id={tooltipId} className="cursor-pointer text-gray-300">
-                <Icon name="braces" size={16} />
-            </a>
-            <Tooltip anchorSelect={`#${tooltipId}`}>
-                <code>
-                    <pre>{JSON.stringify(operationInput, null, 2)}</pre>
-                </code>
-            </Tooltip>
-        </span>
+        <Tooltip content={tooltipContent}>
+            <span className="flex cursor-pointer items-center gap-2 text-xs">
+                {operationType}
+                <Icon name="braces" className="text-gray-300" size={16} />
+            </span>
+        </Tooltip>
     );
 }

--- a/src/connect/components/revision-history/revision/revision-number.tsx
+++ b/src/connect/components/revision-history/revision/revision-number.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
 import { useCopyToClipboard } from 'usehooks-ts';
-import { Tooltip } from '../../tooltip';
 
 export type RevisionNumberProps = {
     operationIndex: number;

--- a/src/connect/components/revision-history/revision/revision-number.tsx
+++ b/src/connect/components/revision-history/revision/revision-number.tsx
@@ -1,7 +1,6 @@
-import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
-import { useId } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
+import { Tooltip } from '../../tooltip';
 
 export type RevisionNumberProps = {
     operationIndex: number;
@@ -10,9 +9,23 @@ export type RevisionNumberProps = {
 };
 export function RevisionNumber(props: RevisionNumberProps) {
     const { operationIndex, eventId, stateHash } = props;
-    const tooltipId = useId().replace(/:/g, '');
     const [, copy] = useCopyToClipboard();
     const revisionNumber = operationIndex + 1;
+
+    const tooltipContent = (
+        <button
+            onClick={handleCopy(stateHash)}
+            className="flex items-center gap-1"
+        >
+            Revision {revisionNumber} - Event ID: {eventId} - State Hash:{' '}
+            {stateHash}
+            <Icon
+                name="files-earmark"
+                className="inline-block text-gray-600"
+                size={16}
+            />
+        </button>
+    );
     function handleCopy(text: string) {
         return () => {
             copy(text).catch(error => {
@@ -22,29 +35,17 @@ export function RevisionNumber(props: RevisionNumberProps) {
     }
 
     return (
-        <span className="flex items-center gap-2 text-xs text-gray-600">
-            Revision {revisionNumber}.
-            <a id={tooltipId}>
-                <Icon
-                    name="ellipsis"
-                    size={14}
-                    className="cursor-pointer text-slate-100"
-                />
-            </a>
-            <Tooltip anchorSelect={`#${tooltipId}`}>
-                <button
-                    onClick={handleCopy(stateHash)}
-                    className="flex items-center gap-1"
-                >
-                    Revision {revisionNumber} - Event ID: {eventId} - State
-                    Hash: {stateHash}
+        <Tooltip content={tooltipContent}>
+            <span className="flex cursor-pointer items-center gap-2 text-xs text-gray-600">
+                Revision {revisionNumber}.
+                <a>
                     <Icon
-                        name="files-earmark"
-                        className="inline-block text-gray-600"
-                        size={16}
+                        name="ellipsis"
+                        size={14}
+                        className="cursor-pointer text-slate-100"
                     />
-                </button>
-            </Tooltip>
-        </span>
+                </a>
+            </span>
+        </Tooltip>
     );
 }

--- a/src/connect/components/revision-history/revision/signature.tsx
+++ b/src/connect/components/revision-history/revision/signature.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@/connect';
 import { Icon } from '@/powerhouse';
-import { useId } from 'react';
 import { type Signature } from '../types';
 
 export type SignatureProps = {
@@ -8,7 +7,6 @@ export type SignatureProps = {
 };
 export function Signature(props: SignatureProps) {
     const { signatures } = props;
-    const tooltipId = useId().replace(/:/g, '');
 
     if (!signatures?.length) return null;
 
@@ -32,32 +30,29 @@ export function Signature(props: SignatureProps) {
         );
     }
 
-    const tooltipContent = signatures.map((signature, index) => {
-        return (
-            <div key={signature.hash} className="mb-2 last:mb-0">
-                <h4>
-                    Signature #{index + 1} -{' '}
-                    {signature.isVerified ? 'verified' : 'unverified'}
-                </h4>
-                <code>
-                    <pre>{JSON.stringify(signature, null, 2)}</pre>
-                </code>
-            </div>
-        );
-    });
+    const tooltipContent = (
+        <div className="text-xs text-slate-300">
+            <h3 className="mb-2">Signature details:</h3>
+            {signatures.map((signature, index) => (
+                <div key={signature.hash} className="mb-2 last:mb-0">
+                    <h4>
+                        Signature #{index + 1} -{' '}
+                        {signature.isVerified ? 'verified' : 'unverified'}
+                    </h4>
+                    <code>
+                        <pre>{JSON.stringify(signature, null, 2)}</pre>
+                    </code>
+                </div>
+            ))}
+        </div>
+    );
 
     return (
-        <span className="flex w-fit items-center gap-1 rounded-lg border border-gray-200 px-2 py-1">
-            <VerificationStatus />{' '}
-            <a id={tooltipId}>
+        <Tooltip content={tooltipContent}>
+            <span className="flex w-fit cursor-pointer items-center gap-1 rounded-lg border border-gray-200 px-2 py-1">
+                <VerificationStatus />{' '}
                 <Icon name="info-square" className="text-gray-300" size={16} />
-            </a>
-            <Tooltip anchorSelect={`#${tooltipId}`}>
-                <div className="text-xs text-slate-300">
-                    <h3 className="mb-2">Signature details:</h3>
-                    {tooltipContent}
-                </div>
-            </Tooltip>
-        </span>
+            </span>
+        </Tooltip>
     );
 }

--- a/src/connect/components/revision-history/revision/timestamp.tsx
+++ b/src/connect/components/revision-history/revision/timestamp.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@/connect';
 import { format } from 'date-fns';
-import { useId } from 'react';
 
 export type TimestampProps = {
     timestamp: number | string;
@@ -8,14 +7,16 @@ export type TimestampProps = {
 
 export function Timestamp(props: TimestampProps) {
     const { timestamp } = props;
-    const tooltipId = useId().replace(/:/g, '');
     const date = new Date(timestamp);
     const shortDate = format(date, "HH:mm 'UTC'");
     const longDate = format(date, "eee, dd MMM yyyy HH:mm:ss 'UTC'");
+    const tooltipContent = <div>{longDate}</div>;
+
     return (
-        <span className="text-xs">
-            <a id={tooltipId}>committed at {shortDate}</a>
-            <Tooltip anchorSelect={`#${tooltipId}`}>{longDate}</Tooltip>
-        </span>
+        <Tooltip content={tooltipContent}>
+            <span className="cursor-pointer text-xs">
+                committed at {shortDate}
+            </span>
+        </Tooltip>
     );
 }

--- a/src/connect/components/revision-history/timeline/timeline.tsx
+++ b/src/connect/components/revision-history/timeline/timeline.tsx
@@ -73,7 +73,8 @@ export function Timeline(props: TimelineProps) {
                 width: '100%',
                 position: 'relative',
             }}
-            className="border-l border-slate-100 px-4"
+            className="border-l border-slate-100
+            "
         >
             {rowVirtualizer.getVirtualItems().map(virtualRow => {
                 const row = rows[virtualRow.index];

--- a/src/connect/components/sidebar/sidebar-user.tsx
+++ b/src/connect/components/sidebar/sidebar-user.tsx
@@ -1,6 +1,5 @@
-import { formatEthAddress } from '@/connect/utils';
+import { ENSAvatar, formatEthAddress } from '@/connect';
 import { useEnsName } from 'wagmi';
-import { ENSAvatar } from '../ens-avatar';
 
 export interface SidebarUserProps {
     address: `0x${string}`;

--- a/src/connect/components/tooltip/tooltip.stories.tsx
+++ b/src/connect/components/tooltip/tooltip.stories.tsx
@@ -1,10 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Tooltip } from './tooltip';
+import { Tooltip, TooltipProvider } from './tooltip';
 
-const meta = {
+const meta: Meta<typeof Tooltip> = {
     title: 'Connect/Components/Tooltip',
     component: Tooltip,
-} satisfies Meta<typeof Tooltip>;
+};
 
 export default meta;
 
@@ -12,16 +12,20 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
     render: function Wrapper(args) {
+        const tooltipContent = (
+            <div>
+                <div>tooltip content</div>
+                <button onClick={() => alert('you can click me')}>
+                    click me
+                </button>
+            </div>
+        );
         return (
-            <>
-                <a id="tooltip">hover me</a>
-                <Tooltip {...args} anchorSelect="#tooltip">
-                    <div>tooltip content</div>
-                    <button onClick={() => alert('you can click me')}>
-                        click me
-                    </button>
+            <TooltipProvider>
+                <Tooltip {...args} content={tooltipContent}>
+                    <a id="tooltip">hover me</a>
                 </Tooltip>
-            </>
+            </TooltipProvider>
         );
     },
 };

--- a/src/connect/components/tooltip/tooltip.tsx
+++ b/src/connect/components/tooltip/tooltip.tsx
@@ -1,24 +1,44 @@
-import { ComponentPropsWithoutRef } from 'react';
-import { Tooltip as ReactTooltip } from 'react-tooltip';
+import * as RadixTooltip from '@radix-ui/react-tooltip';
+import { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
-type Props = ComponentPropsWithoutRef<typeof ReactTooltip>;
+type Props = RadixTooltip.TooltipProps & {
+    className?: string;
+    content: ReactNode;
+};
 
 export function Tooltip(props: Props) {
+    const {
+        children,
+        content,
+        open,
+        defaultOpen,
+        onOpenChange,
+        className,
+        ...rest
+    } = props;
+
     return (
-        <ReactTooltip
-            clickable
-            noArrow
-            border="1px solid var(--gray-200)"
-            opacity={1}
-            {...props}
-            style={{
-                backgroundColor: 'var(--white)',
-                color: 'var(--gray-900)',
-                padding: '8px',
-                borderRadius: '8px',
-                boxShadow: 'var(--shadow-tooltip)',
-                ...props.style,
-            }}
-        />
+        <RadixTooltip.Root
+            open={open}
+            defaultOpen={defaultOpen}
+            onOpenChange={onOpenChange}
+            delayDuration={0}
+        >
+            <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
+            <RadixTooltip.Portal>
+                <RadixTooltip.Content
+                    {...rest}
+                    className={twMerge(
+                        'rounded-lg border border-gray-200 bg-white p-2 text-xs shadow-tooltip',
+                        className,
+                    )}
+                >
+                    {content}
+                </RadixTooltip.Content>
+            </RadixTooltip.Portal>
+        </RadixTooltip.Root>
     );
 }
+
+export const TooltipProvider = RadixTooltip.Provider;

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -22,7 +22,6 @@ import {
     ComponentPropsWithRef,
     ForwardedRef,
     forwardRef,
-    useId,
     useMemo,
     useState,
 } from 'react';
@@ -38,37 +37,35 @@ const TransactionReference = forwardRef(function TransactionReference(
 ) {
     const { control, disabled } = props;
     const value = useWatch({ control, name: 'txRef' });
-    const tooltipId = useId().replace(/:/g, '');
     const maxLength = 46;
     const shouldShortenValue =
         typeof value === 'string' && value.length >= maxLength;
-    const maybeShortedValue = shouldShortenValue
+    const maybeShortenedValue = shouldShortenValue
         ? `${value.slice(0, maxLength)}...`
         : value;
     const isTransaction = getIsTransaction(value);
 
+    const tooltipContent = (
+        <div>
+            <p>{value}</p>
+            {isTransaction && (
+                <p className="mt-2 text-center">
+                    <a
+                        className="text-blue-900 underline"
+                        href={`https://etherscan.io/tx/${value}`}
+                    >
+                        View on Etherscan
+                    </a>
+                </p>
+            )}
+        </div>
+    );
+
     if (disabled)
         return (
-            <span>
-                <a id={tooltipId} className="cursor-pointer">
-                    {maybeShortedValue}
-                </a>
-                {shouldShortenValue && (
-                    <Tooltip anchorSelect={`#${tooltipId}`}>
-                        <p>{value}</p>
-                        {isTransaction && (
-                            <p className="mt-2 text-center">
-                                <a
-                                    className="text-blue-900 underline"
-                                    href={`https://etherscan.io/tx/${value}`}
-                                >
-                                    View on Etherscan
-                                </a>
-                            </p>
-                        )}
-                    </Tooltip>
-                )}
-            </span>
+            <Tooltip content={tooltipContent}>
+                <span>{maybeShortenedValue}</span>
+            </Tooltip>
         );
 
     return <RWATableTextInput {...props} ref={ref} />;


### PR DESCRIPTION
Almost all react tooltip libraries make use of react portals to avoid z index wars. Very strangely, react-tooltip _does not_ support this, and it led to the bug we saw before the demo.

Rather than wrangle with the library to shoehorn in a portal-based implementation, I have instead switched to a different tooltip library which does what we want.

I'm not sure if I'm just imagining it, but I think this library actually makes the revision history more performant too.