### PR TITLE
fix: prevent onclick event propagation when selecting an item option

### DIFF
--- a/src/connect/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/connect/components/dropdown-menu/dropdown-menu.tsx
@@ -36,6 +36,7 @@ export function ConnectDropdownMenu<TItemId extends string>(
                 {items.map(({ id, label, icon, className }) => (
                     <DropdownMenuItem
                         key={id}
+                        onClick={e => e.stopPropagation()}
                         onSelect={() => onItemClick(id)}
                         className={twMerge(
                             'flex items-center px-5 py-2 outline-none first-of-type:rounded-t-2xl first-of-type:pt-3 last-of-type:rounded-b-2xl last-of-type:pb-3 hover:bg-slate-50',


### PR DESCRIPTION
## Description:

- prevent `onclick` event propagation when selecting an item option