### PR TITLE
356 rwa transactions entry time is being adjusted by browser timezone 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@tanstack/react-virtual": "^3.8.1",
     "change-case": "^5.4.3",
     "date-fns": "^3.3.1",
+    "date-fns-tz": "^3.1.3",
     "react-hook-form": "^7.51.2",
     "react-multi-select-component": "^4.3.4",
     "react-number-format": "^5.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   date-fns:
     specifier: ^3.3.1
     version: 3.6.0
+  date-fns-tz:
+    specifier: ^3.1.3
+    version: 3.1.3(date-fns@3.6.0)
   react-hook-form:
     specifier: ^7.51.2
     version: 7.52.2(react@18.3.1)
@@ -8032,6 +8035,14 @@ packages:
       es-errors: 1.3.0
       is-data-view: 1.0.1
     dev: true
+
+  /date-fns-tz@3.1.3(date-fns@3.6.0):
+    resolution: {integrity: sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==}
+    peerDependencies:
+      date-fns: ^3.0.0
+    dependencies:
+      date-fns: 3.6.0
+    dev: false
 
   /date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}

--- a/src/rwa/components/inputs/form-inputs.tsx
+++ b/src/rwa/components/inputs/form-inputs.tsx
@@ -4,6 +4,7 @@ import { twJoin } from 'tailwind-merge';
 type Input = {
     label: string;
     Input: ComponentType;
+    inputLabel?: string | null;
 };
 type Props = {
     inputs: Input[];
@@ -12,7 +13,7 @@ export function FormInputs(props: Props) {
     const { inputs } = props;
     return (
         <div className="bg-white text-xs font-medium">
-            {inputs.map(({ label, Input }, index) => (
+            {inputs.map(({ label, Input, inputLabel }, index) => (
                 <div
                     key={label}
                     className={twJoin(
@@ -23,6 +24,11 @@ export function FormInputs(props: Props) {
                     <div>{label}</div>
                     <div className="h-max py-2 text-gray-900" key={index}>
                         <Input />
+                        {inputLabel && (
+                            <div className="text-left italic text-gray-500">
+                                {inputLabel}
+                            </div>
+                        )}
                     </div>
                 </div>
             ))}

--- a/src/rwa/components/table/assets/useAssetForm.tsx
+++ b/src/rwa/components/table/assets/useAssetForm.tsx
@@ -6,6 +6,7 @@ import {
     RWATableSelect,
     RWATableTextInput,
     convertToDateLocalFormat,
+    formatDateForDisplay,
     handleTableDatum,
 } from '@/rwa';
 import { useMemo, useState } from 'react';
@@ -53,7 +54,7 @@ export function useAssetForm(
           }
         : createDefaultValues;
 
-    const { submit, reset, register, control, formState } = useSubmit({
+    const { submit, reset, register, control, formState, watch } = useSubmit({
         operation,
         createDefaultValues,
         editDefaultValues,
@@ -100,6 +101,11 @@ export function useAssetForm(
             operation,
         ],
     );
+
+    const maturityInputValue =
+        operation === 'view'
+            ? item?.maturity
+            : watch('maturity') || item?.maturity;
 
     const inputs = useMemo(
         () => [
@@ -191,6 +197,9 @@ export function useAssetForm(
                         inputType="date"
                     />
                 ),
+                inputLabel: maturityInputValue
+                    ? formatDateForDisplay(maturityInputValue, true)
+                    : null,
             },
             {
                 label: 'Asset Type',
@@ -242,6 +251,7 @@ export function useAssetForm(
             ...derivedInputsToDisplay,
         ],
         [
+            maturityInputValue,
             derivedInputsToDisplay,
             register,
             operation,

--- a/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
+++ b/src/rwa/components/table/transactions/useGroupTransactionForm.tsx
@@ -12,6 +12,7 @@ import {
     calculateUnitPrice,
     convertToDateTimeLocalFormat,
     feesTransactions,
+    formatDateForDisplay,
     getFixedIncomeAssets,
     groupTransactionTypeLabels,
     makeFixedIncomeOptionLabel,
@@ -217,6 +218,9 @@ export function useGroupTransactionForm(
         [serviceProviderFeeTypes, accounts],
     );
 
+    const entryTimeInputValue =
+        watch('entryTime') || formState.defaultValues?.entryTime;
+
     const inputs = [
         {
             label: 'Transaction Type',
@@ -243,6 +247,9 @@ export function useGroupTransactionForm(
                     name="entryTime"
                 />
             ),
+            inputLabel: entryTimeInputValue
+                ? formatDateForDisplay(new Date(entryTimeInputValue))
+                : null,
         },
         isFeesTransaction
             ? {

--- a/src/rwa/utils/index.ts
+++ b/src/rwa/utils/index.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { assetGroupTransactions } from '../constants';
 import {
     Asset,
@@ -21,8 +22,11 @@ export function convertToDateLocalFormat(date: Date | string = new Date()) {
 }
 
 export function formatDateForDisplay(date: Date | string, displayTime = true) {
-    const formatString = displayTime ? 'yyyy/MM/dd, HH:mm:ss' : 'yyyy/MM/dd';
-    return format(date, formatString);
+    const formatString = displayTime
+        ? 'yyyy/MM/dd, HH:mm:ss zzz'
+        : 'yyyy/MM/dd';
+
+    return formatInTimeZone(date, 'UTC', formatString);
 }
 
 export function isAssetGroupTransactionType(


### PR DESCRIPTION
## Description

- Display dates in tables in UTC
- Added UTC label for date inputs

<img width="1053" alt="Screenshot 2024-09-09 at 4 59 48 PM" src="https://github.com/user-attachments/assets/3530902f-4df1-4173-a087-d8978eafcebc">
<img width="1049" alt="Screenshot 2024-09-09 at 5 00 11 PM" src="https://github.com/user-attachments/assets/0e668a86-92ec-481d-a3b6-8b40bb3bcfc8">
