### PR TITLE
feat: add grid positioning to inner div

### DIFF
--- a/src/connect/components/default-editor-loader/default-editor-loader.tsx
+++ b/src/connect/components/default-editor-loader/default-editor-loader.tsx
@@ -9,8 +9,8 @@ export function DefaultEditorLoader(props: DefaultEditorLoaderProps) {
     const { message = 'Loading editor', ...divProps } = props;
     return (
         <div className="grid h-full place-items-center" {...divProps}>
-            <div className="-mt-20">
-                <h3 className="mb-4 text-center text-xl">{message}</h3>
+            <div className="-mt-20 grid place-items-center">
+                <h3 className="mb-4 text-xl">{message}</h3>
                 <AnimatedLoader />
             </div>
         </div>


### PR DESCRIPTION
Add inner positioning to default loader div to center align animation and text

before:

<img width="321" alt="Screenshot 2024-09-12 at 12 00 07" src="https://github.com/user-attachments/assets/8e552308-8d55-4b69-99d4-1d92234b3c94">

after:

<img width="258" alt="Screenshot 2024-09-12 at 12 07 20" src="https://github.com/user-attachments/assets/b93e83f0-5d82-4d80-b7ba-fff08fbf9f7b">
